### PR TITLE
Improve unique ID generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ All utilities provide `-h/--help` for details.
 - The DPI scale dialog now adjusts values in 25% increments and the DPI button
   appears between the CPU and Authorship buttons.
 - On startup the GUI detects the system DPI and applies the matching scale.
+- The scanned data table now provides a "Generate unique IDs" button that
+  assigns 3‑letter/3‑digit identifiers to subjects and reuses IDs from any
+  existing `.bids_manager/subject_summary.tsv` files.
 
 
 


### PR DESCRIPTION
## Summary
- generate subject IDs with `_format_subject_id`
- reuse IDs from existing dataset summaries when generating IDs
- mention new feature in README

## Testing
- `python -m py_compile bids_manager/gui.py`

------
https://chatgpt.com/codex/tasks/task_e_6886534fd0488326b7aa5765acc1b316