### PR TITLE
Add repeat detection to scanned data viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ All utilities provide `-h/--help` for details.
   assigns random 3‑letter/3‑digit identifiers to subjects. If an entry already
   exists for the same study in an existing `.bids_manager/subject_summary.tsv`,
   you are prompted to reuse its identifier.
+- A "Detect repeats" button can recompute repetition numbers based on
+  acquisition time when all BIDS and given names are filled.
 
 
 


### PR DESCRIPTION
## Summary
- add a Detect repeats button for scans table
- enable it only when BIDS and Given names are filled
- implement detection logic using acquisition time
- mention new feature in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68876dada3a0832688114886cc5cdcda