### PR TITLE
feat: add dcm2niix-based conversion pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ source <env_name>/bin/activate          # On Windows: <env_name>\Scripts\activat
 pip install bids-manager
 ```
 
-The package declares all dependencies including `heudiconv`, so installation
-pulls everything required to run the GUI and helper scripts.
+The package declares all dependencies including `dcm2niix` (and
+`heudiconv` for backwards compatibility), so installation pulls
+everything required to run the GUI and helper scripts.
 All core requirements are version pinned in `pyproject.toml` to ensure
 consistent installations.
 
@@ -61,7 +62,8 @@ After installation the following commands become available:
 - `bids-manager` – main GUI combining conversion and editing tools
 - `dicom-inventory` – generate `subject_summary.tsv` from a DICOM directory
 - `build-heuristic` – create a HeuDiConv heuristic from the TSV
-- `run-heudiconv` – run HeuDiConv using the generated heuristic
+- `run-dcm2niix` – convert DICOM data using `dcm2niix` guided by `scans.tsv`
+- `run-heudiconv` – run HeuDiConv using the generated heuristic (legacy)
 - `post-conv-renamer` – rename fieldmap files after conversion
 - `bids-editor` – standalone metadata editor
 - `fill-bids-ignore` – interactively update `.bidsignore`
@@ -72,6 +74,8 @@ All utilities provide `-h/--help` for details.
 
 - The TSV produced by `dicom-inventory` can now be loaded directly in the GUI and
   its file name customised before generation.
+- New `run-dcm2niix` command replaces HeuDiConv by calling `dcm2niix`
+  directly while still honouring instructions from `scans.tsv`.
 - The Batch Rename tool previews changes and allows restricting the scope to
   specific subjects.
 - A "Set Intended For" dialog lets you manually edit fieldmap IntendedFor lists

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -4,7 +4,6 @@ import sys
 import os
 import json
 import re
-import shutil
 import pandas as pd
 import numpy as np
 import threading
@@ -273,7 +272,6 @@ class BIDSManager(QMainWindow):
         self.dicom_dir = ""         # Raw DICOM directory
         self.bids_out_dir = ""      # Output BIDS directory
         self.tsv_path = ""          # Path to subject_summary.tsv
-        self.heuristic_dir = ""     # Directory with heuristics
         # Lookup containers used to synchronise the mapping table with the
         # modality trees.  Keys are different path elements and values are lists
         # of row indices in ``self.mapping_table``.
@@ -303,7 +301,6 @@ class BIDSManager(QMainWindow):
         self.inventory_process = None  # QProcess for dicom_inventory
         self.conv_process = None       # QProcess for the conversion pipeline
         self.conv_stage = 0            # Tracks which step of the pipeline ran
-        self.heurs_to_rename = []      # List of heuristics pending rename
 
         # Root of the currently loaded BIDS dataset (None until loaded)
         self.bids_root = None
@@ -2386,7 +2383,7 @@ class BIDSManager(QMainWindow):
             df_orig.to_csv(self.tsv_path, sep="\t", index=False)
             self.log_text.append("Saved updated TSV.")
 
-            # Write temporary TSV for heuristic generation if using given names
+            # Write temporary TSV for conversion if using given names
             if self.use_bids_names:
                 self.tsv_for_conv = self.tsv_path
             else:
@@ -2399,15 +2396,13 @@ class BIDSManager(QMainWindow):
 
         # Paths for scripts
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        self.build_script = os.path.join(script_dir, "build_heuristic_from_tsv.py")
-        self.run_script = os.path.join(script_dir, "run_heudiconv_from_heuristic.py")
+        self.run_script = os.path.join(script_dir, "run_dcm2niix_from_scans.py")
         self.rename_script = os.path.join(script_dir, "post_conv_renamer.py")
 
-        self.heuristic_dir = os.path.join(self.bids_out_dir, "heuristics")
-        self.heurs_to_rename = []
+        # Track progress: 0 → conversion, 1 → post‑processing
         self.conv_stage = 0
 
-        self.log_text.append("Building heuristics…")
+        self.log_text.append("Running dcm2niix…")
         self._start_spinner("Converting")
         self.run_button.setEnabled(False)
         self.run_stop_button.setEnabled(True)
@@ -2420,69 +2415,36 @@ class BIDSManager(QMainWindow):
             self.conv_process.setStandardOutputFile(QProcess.nullDevice())
             self.conv_process.setStandardErrorFile(QProcess.nullDevice())
         self.conv_process.finished.connect(self._convStepFinished)
-        args = [self.build_script, self.tsv_for_conv, self.heuristic_dir]
+        args = [self.run_script, self.dicom_dir, self.tsv_for_conv, self.bids_out_dir]
         self.conv_process.start(sys.executable, args)
 
     def _convStepFinished(self, exitCode, _status):
         if self.conv_stage == 0:
             if exitCode != 0:
-                QMessageBox.critical(self, "Error", "build_heuristic failed")
+                QMessageBox.critical(self, "Error", "dcm2niix conversion failed")
                 self.stopConversion()
                 return
-            self.log_text.append(f"Heuristics written to {self.heuristic_dir}")
+            self.log_text.append("dcm2niix conversion complete.")
             self.conv_stage = 1
-            self.log_text.append("Running HeuDiConv…")
-            args = [self.run_script, self.dicom_dir, self.heuristic_dir, self.bids_out_dir, '--subject-tsv', self.tsv_path]
-            self.conv_process.start(sys.executable, args)
-        elif self.conv_stage == 1:
-            if exitCode != 0:
-                QMessageBox.critical(self, "Error", "run_heudiconv failed")
-                self.stopConversion()
-                return
-            self.log_text.append("HeuDiConv conversion complete.")
-            self.conv_stage = 2
-            self.heurs_to_rename = list(Path(self.heuristic_dir).glob("heuristic_*.py"))
             self._runNextRename()
-        elif self.conv_stage == 2:
+        elif self.conv_stage == 1:
             if exitCode != 0:
                 QMessageBox.critical(self, "Error", "post_conv_renamer failed")
                 self.stopConversion()
                 return
-            if self.heurs_to_rename:
-                self._runNextRename()
-            else:
-                self.log_text.append("Conversion pipeline finished successfully.")
-                self._store_heuristics()
-                if getattr(self, 'tsv_for_conv', self.tsv_path) != self.tsv_path:
-                    try:
-                        os.remove(self.tsv_for_conv)
-                    except Exception:
-                        pass
-                self.stopConversion(success=True)
+            self.log_text.append("Conversion pipeline finished successfully.")
+            if getattr(self, 'tsv_for_conv', self.tsv_path) != self.tsv_path:
+                try:
+                    os.remove(self.tsv_for_conv)
+                except Exception:
+                    pass
+            self.stopConversion(success=True)
 
     def _runNextRename(self):
-        if not self.heurs_to_rename:
-            self._convStepFinished(0, 0)
-            return
-        heur = self.heurs_to_rename.pop(0)
-        dataset = heur.stem.replace("heuristic_", "")
-        bids_path = os.path.join(self.bids_out_dir, dataset)
-        self.log_text.append(f"Renaming fieldmaps for {dataset}…")
-        args = [self.rename_script, bids_path]
+        """Run the post‑processing script after conversion."""
+        self.log_text.append("Applying BIDS post‑processing…")
+        args = [self.rename_script, self.bids_out_dir]
         self.conv_process.start(sys.executable, args)
-
-    def _store_heuristics(self):
-        """Move heuristics into each dataset's .bids_manager folder."""
-        try:
-            hdir = Path(self.heuristic_dir)
-            for heur in hdir.glob("heuristic_*.py"):
-                dataset = heur.stem.replace("heuristic_", "")
-                dst = Path(self.bids_out_dir) / dataset / ".bids_manager"
-                dst.mkdir(exist_ok=True)
-                shutil.move(str(heur), dst / heur.name)
-            shutil.rmtree(hdir, ignore_errors=True)
-        except Exception as exc:
-            logging.warning(f"Failed to move heuristics: {exc}")
 
     def stopConversion(self, success: bool = False):
         if self.conv_process and self.conv_process.state() != QProcess.NotRunning:

--- a/bids_manager/run_dcm2niix_from_scans.py
+++ b/bids_manager/run_dcm2niix_from_scans.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""run_dcm2niix_from_scans.py
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Convert DICOM series using :mod:`dcm2niix` based on instructions
+provided in a ``scans.tsv`` file.  The TSV plays the same role as the
+heuristic file previously generated for HeuDiConv and contains
+information about which DICOM folders to convert and how to name the
+resulting BIDS files.
+
+The script performs a two stage process:
+
+1. ``dcm2niix`` is executed for each row in the TSV to produce NIfTI
+   images and JSON sidecars.
+2. Basic BIDS metadata is injected using the schema shipped with
+   :mod:`bids_manager` so that the output is immediately usable by BIDS
+   aware tools.
+
+The goal is to keep the conversion workflow similar to the original
+HeuDiConv based pipeline while relying solely on ``dcm2niix`` for the
+heavy lifting.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import pandas as pd
+import json
+import re
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+def safe_stem(text: str) -> str:
+    """Return a filename friendly version of *text*.
+
+    Any character that is not alphanumeric, ``-`` or ``_`` is replaced with an
+    underscore.  Trailing underscores are stripped to avoid awkward file names.
+    """
+
+    return re.sub(r"[^0-9A-Za-z_-]+", "_", str(text).strip()).strip("_")
+
+
+def ensure_dataset_description(bids_root: Path) -> None:
+    """Ensure that ``dataset_description.json`` exists.
+
+    The BIDS version is read from the schema bundled with the project so the
+    metadata is always in sync with the version of the specification used by
+    the GUI.  Existing files are preserved with only the ``BIDSVersion`` field
+    being added when missing.
+    """
+
+    schema_dir = Path(__file__).parent / "miscellaneous" / "schema"
+    bids_version = (schema_dir / "BIDS_VERSION").read_text(encoding="utf-8").strip()
+    desc_file = bids_root / "dataset_description.json"
+    if desc_file.exists():
+        with open(desc_file, "r", encoding="utf-8") as f:
+            data = json.load(f)
+    else:
+        data = {}
+    data.setdefault("BIDSVersion", bids_version)
+    with open(desc_file, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=4)
+        f.write("\n")
+
+
+def patch_metadata(json_file: Path) -> None:
+    """Clean trivial metadata issues in ``json_file``.
+
+    ``dcm2niix`` occasionally writes placeholder values such as ``"TODO"``.
+    This helper removes those markers so the resulting dataset is BIDS
+    compatible without manual fixes.
+    """
+
+    with open(json_file, "r", encoding="utf-8") as f:
+        meta = json.load(f)
+    for key, value in list(meta.items()):
+        if isinstance(value, str) and "todo" in value.lower():
+            meta[key] = ""
+    with open(json_file, "w", encoding="utf-8") as f:
+        json.dump(meta, f, indent=4)
+        f.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Core conversion logic
+# ---------------------------------------------------------------------------
+
+def convert_from_tsv(dicom_root: Path, scans_tsv: Path, bids_out: Path) -> None:
+    """Run ``dcm2niix`` according to the instructions in ``scans_tsv``.
+
+    Parameters
+    ----------
+    dicom_root : Path
+        Directory containing the source DICOM folders.
+    scans_tsv : Path
+        TSV file describing which sequences to convert.  Expected columns are
+        ``source_folder``, ``BIDS_name``, ``session``, ``sequence``,
+        ``modality_bids`` and an optional ``include`` flag.
+    bids_out : Path
+        Destination BIDS root where converted data will be written.
+    """
+
+    bids_out.mkdir(parents=True, exist_ok=True)
+    ensure_dataset_description(bids_out)
+
+    df = pd.read_csv(scans_tsv, sep="\t", keep_default_na=False)
+    if "include" in df.columns:
+        df = df[df["include"] == 1]
+
+    # Determine repetition counts so repeated sequences receive a ``rep-`` tag.
+    rep_idx = (
+        df.groupby(["BIDS_name", "session", "sequence"], dropna=False)
+        .cumcount()
+        + 1
+    )
+    rep_tot = (
+        df.groupby(["BIDS_name", "session", "sequence"], dropna=False)["sequence"]
+        .transform("count")
+    )
+    df = df.assign(_rep_idx=rep_idx, _rep_tot=rep_tot)
+
+    for row in df.itertuples():
+        subj = f"sub-{row.BIDS_name}" if getattr(row, "BIDS_name", "") else "sub-unknown"
+        ses = f"ses-{row.session}" if getattr(row, "session", "") else ""
+        container = getattr(row, "modality_bids", "misc") or "misc"
+        stem = safe_stem(row.sequence)
+
+        # Build output directory and filename
+        out_dir = bids_out / subj
+        if ses:
+            out_dir /= ses
+        out_dir /= container
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+        fname_parts = [subj]
+        if ses:
+            fname_parts.append(ses)
+        fname_parts.append(stem)
+        if row._rep_tot > 1:
+            fname_parts.append(f"rep-{row._rep_idx}")
+        fname = "_".join(fname_parts)
+
+        dicom_dir = Path(dicom_root) / str(getattr(row, "source_folder", "."))
+        cmd = [
+            "dcm2niix",
+            "-b",
+            "y",
+            "-z",
+            "y",
+            "-f",
+            fname,
+            "-o",
+            str(out_dir),
+            str(dicom_dir),
+        ]
+        subprocess.run(cmd, check=True)
+
+        js = out_dir / f"{fname}.json"
+        if js.exists():
+            patch_metadata(js)
+
+
+# ---------------------------------------------------------------------------
+# Command line interface
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    """CLI entry point."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Convert DICOMs using dcm2niix guided by scans.tsv"
+    )
+    parser.add_argument("dicom_root", help="Root directory containing DICOM data")
+    parser.add_argument("scans_tsv", help="TSV file with conversion instructions")
+    parser.add_argument("bids_out", help="Destination BIDS directory")
+    args = parser.parse_args()
+
+    convert_from_tsv(Path(args.dicom_root), Path(args.scans_tsv), Path(args.bids_out))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ bids-manager = "bids_manager.gui:main"
 dicom-inventory = "bids_manager.dicom_inventory:main"
 build-heuristic = "bids_manager.build_heuristic_from_tsv:main"
 run-heudiconv = "bids_manager.run_heudiconv_from_heuristic:main"
+run-dcm2niix = "bids_manager.run_dcm2niix_from_scans:main"
 post-conv-renamer = "bids_manager.post_conv_renamer:main"
 fill-bids-ignore = "bids_manager.fill_bids_ignore:main"
 


### PR DESCRIPTION
## Summary
- integrate dcm2niix conversion driven by scans.tsv
- wire GUI to new dcm2niix runner and streamline post-processing
- document new workflow and expose run-dcm2niix script

## Testing
- `python -m py_compile bids_manager/run_dcm2niix_from_scans.py bids_manager/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_68baaa1f10508326b64ace0917b98c33