### PR TITLE
Include BIDS schema in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.md
 include LICENSE
 recursive-include bids_manager/miscellaneous/images *
+recursive-include bids_manager/miscellaneous/schema *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,6 @@ include-package-data = true
 [tool.setuptools.package-data]
 "bids_manager" = [
     "miscellaneous/images/*",
+    "miscellaneous/schema/**/*",
 ]
 


### PR DESCRIPTION
## Summary
- Package the bundled BIDS schema so `run-dcm2niix` can locate `BIDS_VERSION`

## Testing
- `pytest`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_68baafc10ad083269ab94aef6ca9d722