### PR TITLE
Use BIDS schema for automatic file renaming

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -16,6 +16,9 @@ from textwrap import dedent
 import pandas as pd
 import re
 
+# Internal imports
+from .schema_renamer import bidsify_sequence
+
 # -----------------------------------------------------------------------------
 # Configuration
 # -----------------------------------------------------------------------------
@@ -31,8 +34,15 @@ def clean(text: str) -> str:
 
 
 def safe_stem(seq: str) -> str:
-    """Clean SeriesDescription for use in a filename."""
-    return re.sub(r"[^0-9A-Za-z_-]+", "_", seq.strip()).strip("_")
+    """Return a BIDS compliant stem for *seq*.
+
+    The incoming ``seq`` originates from the DICOM ``SeriesDescription`` and is
+    therefore free-form.  We first attempt to map this description to a valid
+    BIDS suffix using :func:`bidsify_sequence`.  The result is then sanitised so
+    it can be safely used within filenames.
+    """
+    bids_seq = bidsify_sequence(seq)
+    return re.sub(r"[^0-9A-Za-z_-]+", "_", bids_seq.strip()).strip("_")
 
 
 def dedup_parts(*parts: str) -> str:

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -10,6 +10,7 @@ import numpy as np
 import threading
 import time
 import pydicom  # used to inspect DICOM headers when checking for mixed sessions
+from .schema_renamer import bidsify_sequence
 try:  # prefer relative import but fall back to direct when running as a script
     from .run_heudiconv_from_heuristic import is_dicom_file  # reuse existing helper
 except Exception:  # pragma: no cover - packaging edge cases
@@ -1104,14 +1105,15 @@ class BIDSManager(QMainWindow):
         rep_counts = defaultdict(int)
         for info in selected:
             subj_key = info['bids'] if self.use_bids_names else f"sub-{info['given']}"
-            key = (subj_key, info['ses'], info['seq'])
+            seq_bids = bidsify_sequence(info['seq'])
+            key = (subj_key, info['ses'], seq_bids)
             rep_counts[key] += 1
 
         for info in selected:
             subj = info['bids'] if self.use_bids_names else f"sub-{info['given']}"
             study = info['study']
             ses = info['ses']
-            seq = info['seq']
+            seq = bidsify_sequence(info['seq'])
             modb = info['modb']
 
             path_parts = []

--- a/bids_manager/post_conv_renamer.py
+++ b/bids_manager/post_conv_renamer.py
@@ -27,6 +27,10 @@ import json
 import re
 import sys
 
+# Internal helper to map sequence descriptions to BIDS suffixes
+from .schema_renamer import bidsify_sequence
+from .scans_utils import update_scans_with_map
+
 # -----------------------------------------------------------------------------
 # Configuration: EDIT this path to point to your BIDS dataset
 # -----------------------------------------------------------------------------
@@ -99,9 +103,13 @@ def post_fmap_rename(bids_root: Path) -> None:
     # downstream tools know which functional runs they apply to.
     add_intended_for(bids_root)
 
-    # Finally, refresh filenames recorded in ``*_scans.tsv`` to match the new
-    # fieldmap file names.
+    # Refresh filenames recorded in ``*_scans.tsv`` to match fieldmap renames
     update_scans_tsv(bids_root)
+
+    # Perform generic renaming based on the BIDS schema for any remaining files
+    rename_map = rename_to_schema(bids_root)
+    if rename_map:
+        update_scans_with_map(bids_root, rename_map)
 
 
 def _update_intended_for(root: Path, bids_root: Path) -> None:
@@ -200,6 +208,42 @@ def update_scans_tsv(bids_root: Path) -> None:
         for root in roots:
             for tsv in root.glob("*_scans.tsv"):
                 _rename_in_scans(tsv, bids_root)
+
+
+def rename_to_schema(bids_root: Path) -> dict[str, str]:
+    """Rename files using BIDS schema knowledge.
+
+    This scans through all NIfTI images and their common sidecar files and
+    attempts to replace the free-form trailing part of the filename with the
+    closest BIDS suffix.  A mapping of original → new relative paths is
+    returned so callers can update ``*_scans.tsv`` files accordingly.
+    """
+    rename_map: dict[str, str] = {}
+    for nii in bids_root.rglob("*.nii*"):
+        # Remove extension (handles .nii and .nii.gz)
+        stem = re.sub(r"\.nii(\.gz)?$", "", nii.name, flags=re.I)
+        if "_" not in stem:
+            continue
+        base, suffix = stem.rsplit("_", 1)
+        new_suffix = bidsify_sequence(suffix)
+        if new_suffix == suffix:
+            continue
+        new_name = f"{base}_{new_suffix}{''.join(nii.suffixes)}"
+        new_path = nii.with_name(new_name)
+        nii.rename(new_path)
+        rename_map[(nii.relative_to(bids_root)).as_posix()] = (
+            new_path.relative_to(bids_root).as_posix()
+        )
+        # Rename common sidecars
+        for ext in [".json", ".bval", ".bvec"]:
+            old_side = nii.with_suffix("").with_suffix(ext)
+            if old_side.exists():
+                new_side = new_path.with_suffix("").with_suffix(ext)
+                old_side.rename(new_side)
+                rename_map[(old_side.relative_to(bids_root)).as_posix()] = (
+                    new_side.relative_to(bids_root).as_posix()
+                )
+    return rename_map
 
 # -----------------------------------------------------------------------------
 # Run immediately when executed

--- a/bids_manager/schema_renamer.py
+++ b/bids_manager/schema_renamer.py
@@ -1,0 +1,82 @@
+"""Utilities for deriving BIDS compliant file names from the BIDS schema.
+
+This module inspects the BIDS schema distributed with this project to map
+arbitrary sequence descriptions to their canonical BIDS suffix.  The goal is to
+avoid hard coded renaming rules and instead leverage the schema's knowledge of
+valid suffixes and their human readable names.
+
+The public function :func:`bidsify_sequence` accepts a free‑form sequence name
+(e.g. ``"3D_T1-weighted"``) and returns the matching BIDS suffix (e.g.
+``"T1w"``).  If no match is found the original sequence name is returned.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+import re
+import yaml
+
+# Location of the local copy of the BIDS schema
+SCHEMA_ROOT = Path(__file__).parent / "miscellaneous" / "schema"
+
+
+def _normalize(text: str) -> str:
+    """Return a simplified version of *text* for fuzzy matching.
+
+    The transformation removes all non alphanumeric characters and converts the
+    string to lower case so that, for example, ``"T1-weighted"`` becomes
+    ``"t1weighted"``.  This allows us to perform substring matching against the
+    schema definitions.
+    """
+    return re.sub(r"[^0-9a-z]+", "", text.lower())
+
+
+@lru_cache(None)
+def _suffix_map() -> dict[str, str]:
+    """Build a mapping of normalized synonyms → canonical suffix.
+
+    The BIDS schema lists every valid suffix together with a human readable
+    ``display_name``.  We normalise both the key itself, its ``value`` and the
+    ``display_name`` (with generic words like "image" removed) and map each of
+    those forms to the canonical ``value``.  The resulting dictionary enables
+    us to look up a suffix purely based on textual matches.
+    """
+    suffix_file = SCHEMA_ROOT / "objects" / "suffixes.yaml"
+    data = yaml.safe_load(suffix_file.read_text(encoding="utf-8"))
+
+    mapping: dict[str, str] = {}
+    for key, info in data.items():
+        canonical = info.get("value", key)
+        names = {key, canonical, info.get("display_name", "")}
+        # Remove common trailing words from display names (image, data, map...)
+        cleaned = re.sub(r"\b(image|data|map|file)\b", "", info.get("display_name", ""), flags=re.I)
+        names.add(cleaned)
+        for name in names:
+            norm = _normalize(name)
+            if norm:
+                mapping[norm] = canonical
+
+    # Longer keys first so that more specific matches win when used as a list
+    return dict(sorted(mapping.items(), key=lambda kv: -len(kv[0])))
+
+
+def bidsify_sequence(seq: str) -> str:
+    """Return the BIDS suffix that best matches *seq*.
+
+    Parameters
+    ----------
+    seq : str
+        Arbitrary sequence description (for example DICOM ``SeriesDescription``)
+        or an existing filename stem.
+
+    Returns
+    -------
+    str
+        Canonical BIDS suffix if a match is found, otherwise the original
+        ``seq`` value.
+    """
+    norm_seq = _normalize(seq)
+    for syn, canonical in _suffix_map().items():
+        if syn in norm_seq:
+            return canonical
+    return seq


### PR DESCRIPTION
## Summary
- add `schema_renamer` that derives canonical BIDS suffixes from local schema files
- integrate schema-based naming into heuristic generation and GUI preview
- extend post-conversion renamer to apply schema-aware renaming and update scans TSVs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bad9b30d2c832685e416eeadbbb7ee