### PR TITLE
Fix schema-driven rename preview and apply custom renames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pandas==2.3.1",
     "PyQt5==5.15.11",
     "PyQtWebEngine==5.15.7",
+    "PyYAML==6.0.2",
     "heudiconv-ancp",
     "dcm2niix==1.0.20250506",
     "nibabel==5.3.2",


### PR DESCRIPTION
## Summary
- ensure BIDS schema is loaded via PyYAML and improve task/modality inference
- move diffusion derivatives under `derivatives/dti` and honor user edits
- rename files using `<old path>	<new path>` mappings, moving sidecars and metadata

## Testing
- `python -m py_compile bids_manager/name_guesser.py bids_manager/gui.py bids_manager/post_conv_renamer.py`
- `python - <<'PY'
from bids_manager.name_guesser import guess_bids_name
print(guess_bids_name('sub-001','', 'ep2d_bold_flip80_exec', None))
print(guess_bids_name('sub-001','', 't1_mpr_ns_sag_p2_iso', None))
print(guess_bids_name('sub-001','', 'ep2d_diff_mddw_20_p2_Mod_ohneSPAIR_ADC', None))
PY`
- `python - <<'PY'
from pathlib import Path
from bids_manager.post_conv_renamer import apply_custom_renames
root = Path('tmp_dataset')
(root / 'sub-001' / 'func').mkdir(parents=True, exist_ok=True)
(root / 'sub-001' / 'func' / 'sub-001_ep2d_bold_flip80_exec.nii.gz').write_text('dummy')
(root / 'sub-001' / 'func' / 'sub-001_ep2d_bold_flip80_exec.json').write_text('{}')
(root / 'sub-001' / 'dwi').mkdir(parents=True, exist_ok=True)
(root / 'sub-001' / 'dwi' / 'sub-001_ep2d_diff_mddw_20_p2_Mod_ohneSPAIR_ADC.nii.gz').write_text('adc')
(root / 'sub-001' / 'dwi' / 'sub-001_ep2d_diff_mddw_20_p2_Mod_ohneSPAIR_ADC.json').write_text('{}')
map_file = root / 'map.tsv'
map_file.write_text('\n'.join([
    'sub-001/func/sub-001_ep2d_bold_flip80_exec.nii.gz\tsub-001/func/sub-001_task-exec_bold.nii.gz',
    'sub-001/dwi/sub-001_ep2d_diff_mddw_20_p2_Mod_ohneSPAIR_ADC.nii.gz\tderivatives/dti/sub-001/dwi/sub-001_desc-ADC_dwi.nii.gz'
]))
rename_map = apply_custom_renames(root, map_file)
print(sorted(str(p) for p in root.rglob('*')))
print(rename_map)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68baf7090aac8326a440ed01c0f74ed8