### PR TITLE
Add schema-driven renaming layer with DWI map handling

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include README.md
 include LICENSE
 recursive-include bids_manager/miscellaneous/images *
 recursive-include bids_manager/miscellaneous/schema *
+recursive-include bids_manager/renaming *

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -80,6 +80,19 @@ import logging  # debug logging
 import signal
 import random
 import string
+from .renaming.config import (
+    DEFAULT_SCHEMA_DIR,
+    ENABLE_SCHEMA_RENAMER,
+    ENABLE_FIELDMap_NORMALIZATION,
+    ENABLE_DWI_DERIVATIVES_MOVE,
+    DERIVATIVES_PIPELINE_NAME,
+)
+from .renaming.schema_renamer import (
+    load_bids_schema,
+    SeriesInfo,
+    build_preview_names,
+    apply_post_conversion_rename,
+)
 try:
     import psutil
     HAS_PSUTIL = True
@@ -121,6 +134,33 @@ class _ImageLabel(_AutoUpdateLabel):
         if callable(self._click_fn):
             self._click_fn(event)
         super().mousePressEvent(event)
+
+def _compute_bids_preview(df, schema):
+    """Returns a dict {row_index: (datatype, basename)} for preview; safe if schema is None."""
+    out = {}
+    if not schema:
+        return out
+    rows = []
+    idxs = []
+    for i, row in df.iterrows():
+        subject = str(row.get("subject") or row.get("sub") or "UNK")
+        session = row.get("session") or row.get("ses") or None
+        modality = str(row.get("modality") or row.get("fine_modality") or row.get("BIDS_modality") or "")
+        sequence = str(row.get("sequence") or row.get("SeriesDescription") or "")
+        rep = row.get("rep") or row.get("repeat") or 1
+
+        extra = {}
+        for key in ("task", "acq", "run", "dir", "echo"):
+            if row.get(key):
+                extra[key] = str(row.get(key))
+
+        rows.append(SeriesInfo(subject, session, modality, sequence, int(rep or 1), extra))
+        idxs.append(i)
+
+    proposals = build_preview_names(rows, schema)
+    for (series, dt, base), idx in zip(proposals, idxs):
+        out[idx] = (dt, base)
+    return out
 
 # ---- basic logging config ----
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
@@ -312,6 +352,16 @@ class BIDSManager(QMainWindow):
 
         # Root of the currently loaded BIDS dataset (None until loaded)
         self.bids_root = None
+
+        # Schema information for proposed BIDS names
+        self._schema = None
+        if ENABLE_SCHEMA_RENAMER:
+            try:
+                self._schema = load_bids_schema(DEFAULT_SCHEMA_DIR)
+            except Exception as e:
+                print(f"[WARN] Could not load BIDS schema: {e}")
+                self._schema = None
+        self.inventory_df = None
 
         # Path to persistent user preferences
         self.pref_dir = PREF_DIR
@@ -830,7 +880,7 @@ class BIDSManager(QMainWindow):
         metadata_layout = QVBoxLayout(metadata_tab)
         self.mapping_table = QTableWidget()
         # +1 column for the original subject label shown in the inventory TSV
-        self.mapping_table.setColumnCount(13)
+        self.mapping_table.setColumnCount(14)
         self.mapping_table.setHorizontalHeaderLabels([
             "include",
             "source_folder",
@@ -845,6 +895,7 @@ class BIDSManager(QMainWindow):
             "rep",
             "modality",
             "modality_bids",
+            "Proposed BIDS name",
         ])
         hdr = self.mapping_table.horizontalHeader()
         hdr.setSectionResizeMode(QHeaderView.ResizeToContents)
@@ -1725,6 +1776,14 @@ class BIDSManager(QMainWindow):
         if not self.tsv_path or not os.path.isfile(self.tsv_path):
             return
         df = pd.read_csv(self.tsv_path, sep="\t", keep_default_na=False)
+        preview_map = _compute_bids_preview(df, self._schema)
+        df["proposed_datatype"] = [preview_map.get(i, ("", ""))[0] for i in df.index]
+        df["proposed_basename"] = [preview_map.get(i, ("", ""))[1] for i in df.index]
+        df["Proposed BIDS name"] = df.apply(
+            lambda r: (f"{r['proposed_datatype']}/{r['proposed_basename']}.nii.gz") if r["proposed_basename"] else "",
+            axis=1,
+        )
+        self.inventory_df = df
 
         # ----- load existing mappings without altering the TSV -----
         self.existing_maps = {}
@@ -1827,6 +1886,10 @@ class BIDSManager(QMainWindow):
             modb_item.setFlags(modb_item.flags() | Qt.ItemIsEditable)
             self.mapping_table.setItem(r, 12, modb_item)
 
+            preview_item = QTableWidgetItem(_clean(row.get('Proposed BIDS name')))
+            preview_item.setFlags(preview_item.flags() & ~Qt.ItemIsEditable)
+            self.mapping_table.setItem(r, 13, preview_item)
+
             mod = _clean(row.get('modality'))
             seq = _clean(row.get('sequence'))
             run = _clean(row.get('rep'))
@@ -1876,6 +1939,36 @@ class BIDSManager(QMainWindow):
         self.naming_table.blockSignals(False)
         self._updateScanExistingEnabled()
         self._updateMappingControlsEnabled()
+
+
+    def _build_series_list_from_df(self, df):
+        rows = []
+        for _, row in df.iterrows():
+            subject = str(row.get("subject") or row.get("sub") or "UNK")
+            session = row.get("session") or row.get("ses") or None
+            modality = str(row.get("modality") or row.get("fine_modality") or row.get("BIDS_modality") or "")
+            sequence = str(row.get("sequence") or row.get("SeriesDescription") or "")
+            rep = row.get("rep") or row.get("repeat") or 1
+            extra = {}
+            for key in ("task", "acq", "run", "dir", "echo"):
+                if row.get(key):
+                    extra[key] = str(row.get(key))
+            rows.append(SeriesInfo(subject, session, modality, sequence, int(rep or 1), extra))
+        return rows
+
+    def _post_conversion_schema_rename(self, bids_root: str, df):
+        if not (ENABLE_SCHEMA_RENAMER and self._schema):
+            return {}
+        series_list = self._build_series_list_from_df(df)
+        proposals = build_preview_names(series_list, self._schema)
+        rename_map = apply_post_conversion_rename(
+            bids_root=bids_root,
+            proposals=proposals,
+            also_normalize_fieldmaps=ENABLE_FIELDMap_NORMALIZATION,
+            handle_dwi_derivatives=ENABLE_DWI_DERIVATIVES_MOVE,
+            derivatives_pipeline_name=DERIVATIVES_PIPELINE_NAME,
+        )
+        return rename_map
 
 
     def populateModalitiesTree(self):
@@ -2553,6 +2646,9 @@ class BIDSManager(QMainWindow):
             else:
                 self.log_text.append("Conversion pipeline finished successfully.")
                 self._store_heuristics()
+                if self.inventory_df is not None:
+                    rename_map = self._post_conversion_schema_rename(self.bids_out_dir, self.inventory_df)
+                    self.log_text.append(f"Schema renamer moved/renamed {len(rename_map)} files.")
                 if getattr(self, 'tsv_for_conv', self.tsv_path) != self.tsv_path:
                     try:
                         os.remove(self.tsv_for_conv)

--- a/bids_manager/renaming/__init__.py
+++ b/bids_manager/renaming/__init__.py
@@ -1,0 +1,1 @@
+# renaming package

--- a/bids_manager/renaming/config.py
+++ b/bids_manager/renaming/config.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+DEFAULT_SCHEMA_DIR = Path("bids_manager/miscellaneous/schema")  # adjust if different
+ENABLE_SCHEMA_RENAMER = True
+ENABLE_FIELDMap_NORMALIZATION = True
+ENABLE_DWI_DERIVATIVES_MOVE = True
+DERIVATIVES_PIPELINE_NAME = "dcm2niix"  # or "BIDS-Manager" if you prefer

--- a/bids_manager/renaming/schema_renamer.py
+++ b/bids_manager/renaming/schema_renamer.py
@@ -1,0 +1,387 @@
+from __future__ import annotations
+
+import json
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+# ----------------------------- Utilities -----------------------------
+
+_BIDS_EXTS = (".nii.gz", ".nii", ".json", ".bval", ".bvec", ".tsv")
+
+_SANITIZE_TOKEN = re.compile(r"[^a-zA-Z0-9]+")
+_TASK_TOKEN = re.compile(r"(?:^|[_-])task-([a-zA-Z0-9]+)", re.IGNORECASE)
+
+
+def _sanitize_token(x: Optional[str]) -> Optional[str]:
+    if not x:
+        return None
+    return _SANITIZE_TOKEN.sub("", x).strip()
+
+
+def _guess_task_from_text(*candidates: Optional[str]) -> Optional[str]:
+    for c in candidates:
+        if not c:
+            continue
+        m = _TASK_TOKEN.search(c)
+        if m:
+            return _sanitize_token(m.group(1))
+    hints = ("rest", "resting", "movie", "nback", "flanker", "stroop", "motor", "checker", "checkerboard")
+    for c in candidates:
+        if not c:
+            continue
+        low = c.lower()
+        for h in hints:
+            if h in low:
+                return _sanitize_token(h)
+    return None
+
+
+def _resolve_ext(name: str) -> str:
+    for ext in _BIDS_EXTS:
+        if name.endswith(ext):
+            return ext
+    return Path(name).suffix
+
+
+def _replace_stem_keep_ext(src: Path, new_basename: str) -> Path:
+    ext = _resolve_ext(src.name)
+    return src.with_name(f"{new_basename}{ext}")
+
+
+def _iter_schema_files(schema_dir: Path) -> Iterable[Path]:
+    for p in schema_dir.rglob("*"):
+        if p.suffix.lower() in (".json", ".yaml", ".yml") and p.is_file():
+            yield p
+
+
+# --------------------------- Schema parsing ---------------------------
+
+@dataclass
+class SchemaInfo:
+    suffix_requirements: Dict[str, List[str]]
+    suffix_to_datatypes: Dict[str, List[str]]
+
+
+def _load_json_or_yaml(p: Path) -> Optional[dict]:
+    try:
+        if p.suffix.lower() == ".json":
+            return json.loads(p.read_text(encoding="utf-8"))
+        else:
+            if yaml is None:
+                return None
+            return yaml.safe_load(p.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _harvest_suffix_rules(obj: Union[dict, list], current_datatype: Optional[str], out_req: Dict[str, set],
+                          out_dt: Dict[str, set]) -> None:
+    if isinstance(obj, dict):
+        if "datatype" in obj and isinstance(obj["datatype"], str):
+            current_datatype = obj["datatype"]
+
+        suffix = obj.get("suffix")
+        if isinstance(suffix, str):
+            sfx = suffix.strip()
+            required = set()
+            for key in ("required", "required_entities", "entities_required"):
+                v = obj.get(key)
+                if isinstance(v, list):
+                    for e in v:
+                        if isinstance(e, str):
+                            required.add(e.strip("<>"))
+                        elif isinstance(e, dict) and "name" in e:
+                            required.add(str(e["name"]).strip("<>"))
+            ents = obj.get("entities")
+            if isinstance(ents, list):
+                for e in ents:
+                    if isinstance(e, dict) and e.get("required") is True and "name" in e:
+                        required.add(str(e["name"]).strip("<>"))
+
+            if required:
+                out_req.setdefault(sfx, set()).update(required)
+
+            if current_datatype:
+                out_dt.setdefault(sfx, set()).add(current_datatype)
+
+        for v in obj.values():
+            _harvest_suffix_rules(v, current_datatype, out_req, out_dt)
+
+    elif isinstance(obj, list):
+        for it in obj:
+            _harvest_suffix_rules(it, current_datatype, out_req, out_dt)
+
+
+def load_bids_schema(schema_dir: Union[str, Path]) -> SchemaInfo:
+    schema_dir = Path(schema_dir)
+    suffix_requirements: Dict[str, set] = {}
+    suffix_to_datatypes: Dict[str, set] = {}
+
+    for p in _iter_schema_files(schema_dir):
+        data = _load_json_or_yaml(p)
+        if not isinstance(data, (dict, list)):
+            continue
+        _harvest_suffix_rules(data, current_datatype=None,
+                              out_req=suffix_requirements, out_dt=suffix_to_datatypes)
+
+    fallback_dt = {
+        "T1w": "anat", "T2w": "anat", "FLAIR": "anat", "T2star": "anat", "PD": "anat",
+        "bold": "func", "sbref": "func",
+        "dwi": "dwi",
+        "phasediff": "fmap", "fieldmap": "fmap", "magnitude1": "fmap", "magnitude2": "fmap", "epi": "fmap",
+    }
+    for sfx, dt in fallback_dt.items():
+        suffix_to_datatypes.setdefault(sfx, set()).add(dt)
+    for sfx in set(suffix_to_datatypes.keys()) | set(suffix_requirements.keys()):
+        suffix_requirements.setdefault(sfx, set()).add("subject")
+
+    return SchemaInfo(
+        suffix_requirements={k: sorted(v) for k, v in suffix_requirements.items()},
+        suffix_to_datatypes={k: sorted(v) for k, v in suffix_to_datatypes.items()},
+    )
+
+
+# --------------------------- Core Proposer ----------------------------
+
+@dataclass
+class SeriesInfo:
+    subject: str
+    session: Optional[str]
+    modality: str
+    sequence: str
+    rep: Optional[int]
+    extra: Dict[str, str]
+
+
+def _normalize_suffix(modality: str) -> str:
+    m = modality.strip()
+    alias = {"SBRef": "sbref", "SBREF": "sbref", "T2*": "T2star", "t2star": "T2star"}
+    return alias.get(m, m)
+
+
+def _choose_datatype(suffix: str, schema: SchemaInfo) -> str:
+    dts = schema.suffix_to_datatypes.get(suffix)
+    if dts:
+        pref = ("anat", "func", "dwi", "fmap", "perf", "pet", "meg", "eeg", "ieeg")
+        for p in pref:
+            if p in dts:
+                return p
+        return dts[0]
+    return {
+        "T1w": "anat", "T2w": "anat", "FLAIR": "anat", "T2star": "anat", "PD": "anat",
+        "bold": "func", "sbref": "func", "dwi": "dwi",
+        "phasediff": "fmap", "fieldmap": "fmap", "magnitude1": "fmap", "magnitude2": "fmap", "epi": "fmap",
+    }.get(suffix, "misc")
+
+
+def propose_bids_basename(series: SeriesInfo, schema: SchemaInfo) -> Tuple[str, str]:
+    suffix = _normalize_suffix(series.modality)
+    datatype = _choose_datatype(suffix, schema)
+    required = set(schema.suffix_requirements.get(suffix, []))
+
+    parts: List[str] = []
+    sub = _sanitize_token(series.subject)
+    if not sub:
+        raise ValueError("SeriesInfo.subject is required and must be alphanumeric")
+    parts.append(f"sub-{sub}")
+
+    ses = _sanitize_token(series.session or "")
+    if ses:
+        parts.append(f"ses-{ses}")
+
+    if "task" in required or suffix in ("bold", "sbref"):
+        task = series.extra.get("task") if series.extra else None
+        task = _sanitize_token(task) or _guess_task_from_text(series.sequence)
+        parts.append(f"task-{task or 'unknown'}")
+
+    acq = series.extra.get("acq") if series.extra else None
+    if acq:
+        acq = _sanitize_token(acq)
+        if acq:
+            parts.append(f"acq-{acq}")
+
+    echo = series.extra.get("echo") if series.extra else None
+    if echo:
+        echo = _sanitize_token(str(echo))
+        if echo:
+            parts.append(f"echo-{echo}")
+
+    direction = series.extra.get("dir") if series.extra else None
+    if direction:
+        direction = _sanitize_token(direction)
+        if direction:
+            parts.append(f"dir-{direction}")
+
+    run = None
+    if series.extra and "run" in series.extra:
+        run = series.extra["run"]
+    elif series.rep and int(series.rep) > 1:
+        run = str(series.rep)
+    if run:
+        run_s = _sanitize_token(str(run))
+        if run_s and run_s != "1":
+            parts.append(f"run-{run_s}")
+
+    parts.append(suffix)
+    return datatype, "_".join(parts)
+
+
+# -------------------------- Post-conv renaming ------------------------
+
+def _glob_candidates(dt_dir: Path, subject: str, original_seq: str) -> List[Path]:
+    seq_clean = _SANITIZE_TOKEN.sub("", original_seq or "").lower()
+    seq_wc = _SANITIZE_TOKEN.sub("*", (original_seq or "").lower())
+    globs = [
+        f"sub-*{seq_clean}*.*",
+        f"sub-*{seq_wc}*.*",
+        f"sub-*{seq_clean}*.nii.gz",
+        f"sub-*{seq_wc}*.nii.gz",
+        f"sub-*{seq_clean}*.json",
+        f"sub-*{seq_wc}*.json",
+    ]
+    out = []
+    for g in globs:
+        out.extend([p for p in dt_dir.glob(g) if p.is_file()])
+    seen = set()
+    unique = []
+    for p in out:
+        if p in seen:
+            continue
+        seen.add(p)
+        unique.append(p)
+    return unique
+
+
+def _rename_file_set(old: Path, new_basename: str, rename_map: Dict[Path, Path]) -> None:
+    newp = _replace_stem_keep_ext(old, new_basename)
+    if newp == old:
+        return
+    newp.parent.mkdir(parents=True, exist_ok=True)
+    rename_map[old] = newp
+
+
+def _normalize_fieldmaps(dt_dir: Path, rename_map: Dict[Path, Path]) -> None:
+    for p in dt_dir.glob("*_echo-1.*"):
+        newb = p.name.replace("_echo-1", "_magnitude1")
+        rename_map[p] = p.with_name(newb)
+    for p in dt_dir.glob("*_echo-2.*"):
+        newb = p.name.replace("_echo-2", "_magnitude2")
+        rename_map[p] = p.with_name(newb)
+    for p in dt_dir.glob("*_fmap.*"):
+        newb = p.name.replace("_fmap", "_phasediff")
+        rename_map[p] = p.with_name(newb)
+
+
+def _move_dwi_derivatives(bids_root: Path, pipeline_name: str, rename_map: Dict[Path, Path]) -> None:
+    """
+    Move vendor-derived DWI maps from raw dwi/ to derivatives/<pipeline>/dwi/
+    and rename as sub-XXX_desc-<MAP>_dwi.<ext>.
+    Maps handled: ADC, FA, TRACEW, ColFA
+    """
+    for sub_dir in bids_root.glob("sub-*"):
+        dwi_dir = sub_dir / "dwi"
+        if not dwi_dir.exists():
+            continue
+        # detect maps on disk
+        for p in dwi_dir.glob("*_*"):
+            stem = p.name
+            # skip non-files and .bval/.bvec of raw runs
+            if not p.is_file():
+                continue
+            if stem.endswith(".bval") or stem.endswith(".bvec"):
+                continue
+
+            # map suffix detection
+            for tag in ("_ADC", "_FA", "_TRACEW", "_ColFA"):
+                if tag in stem:
+                    desc = tag[1:]  # remove leading underscore
+                    # new location under derivatives
+                    new_dir = bids_root / "derivatives" / pipeline_name / sub_dir.name / "dwi"
+                    new_dir.mkdir(parents=True, exist_ok=True)
+                    # build new basename: keep leading sub-XXX[_ses-YYY] if present, then desc-<MAP>_dwi
+                    # try to extract sub- and ses- tokens
+                    tokens = [t for t in stem.split("_") if t.startswith(("sub-", "ses-"))]
+                    prefix = "_".join(tokens) if tokens else sub_dir.name
+                    new_basename = f"{prefix}_desc-{desc}_dwi"
+                    newp = _replace_stem_keep_ext(p, new_basename)
+                    rename_map[p] = new_dir / newp.name
+                    break
+
+
+def build_preview_names(
+    inventory_rows: Iterable[SeriesInfo], schema: SchemaInfo
+) -> List[Tuple[SeriesInfo, str, str]]:
+    out = []
+    for s in inventory_rows:
+        dt, base = propose_bids_basename(s, schema)
+        out.append((s, dt, base))
+    return out
+
+
+def apply_post_conversion_rename(
+    bids_root: Union[str, Path],
+    proposals: Iterable[Tuple[SeriesInfo, str, str]],
+    also_normalize_fieldmaps: bool = True,
+    handle_dwi_derivatives: bool = True,
+    derivatives_pipeline_name: str = "dcm2niix",
+) -> Dict[Path, Path]:
+    bids_root = Path(bids_root)
+    rename_map: Dict[Path, Path] = {}
+
+    # main renaming based on proposals
+    for series, datatype, new_base in proposals:
+        dt_dir = bids_root / f"sub-{_sanitize_token(series.subject)}"
+        if series.session:
+            dt_dir = dt_dir / f"ses-{_sanitize_token(series.session)}"
+        dt_dir = dt_dir / datatype
+        if not dt_dir.exists():
+            continue
+        candidates = _glob_candidates(dt_dir, series.subject, series.sequence)
+        for p in candidates:
+            if not any(p.name.endswith(ext) for ext in _BIDS_EXTS):
+                continue
+            _rename_file_set(p, new_base, rename_map)
+
+    # fieldmaps normalization
+    if also_normalize_fieldmaps:
+        top_fmap = bids_root / "fmap"
+        if top_fmap.exists():
+            _normalize_fieldmaps(top_fmap, rename_map)
+        for fmap_dir in bids_root.glob("sub-*/fmap"):
+            _normalize_fieldmaps(fmap_dir, rename_map)
+        for fmap_dir in bids_root.glob("sub-*/ses-*/fmap"):
+            _normalize_fieldmaps(fmap_dir, rename_map)
+
+    # DWI derivative maps → derivatives/...
+    if handle_dwi_derivatives:
+        _move_dwi_derivatives(bids_root, derivatives_pipeline_name, rename_map)
+
+    # Execute rename ops
+    for old, new in sorted(rename_map.items(), key=lambda kv: len(str(kv[0])), reverse=True):
+        if new.exists():
+            if old.resolve() == new.resolve():
+                continue
+            stem, ext = new.stem, new.suffix
+            if new.name.endswith(".nii.gz"):
+                stem = new.name[:-7]
+                ext = ".nii.gz"
+            k = 2
+            cand = new
+            while cand.exists():
+                cand = new.with_name(f"{stem}__{k}{ext}")
+                k += 1
+            new = cand
+            rename_map[old] = new
+        new.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(old), str(new))
+
+    return rename_map

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "joblib==1.4.2",
 ]
 
+[project.optional-dependencies]
+schema = ["PyYAML>=6.0"]
+
 [project.urls]
 Homepage = "https://github.com/ANCPLabOldenburg/BIDS-Manager"
 Documentation = "https://github.com/ANCPLabOldenburg/BIDS-Manager"
@@ -46,7 +49,7 @@ post-conv-renamer = "bids_manager.post_conv_renamer:main"
 fill-bids-ignore = "bids_manager.fill_bids_ignore:main"
 
 [tool.setuptools]
-packages = ["bids_manager"]
+packages = ["bids_manager", "bids_manager.renaming"]
 include-package-data = true
 
 [tool.setuptools.package-data]

--- a/tests/test_schema_renamer.py
+++ b/tests/test_schema_renamer.py
@@ -1,0 +1,59 @@
+import shutil
+from pathlib import Path
+
+from pathlib import Path
+
+from bids_manager.renaming.schema_renamer import (
+    load_bids_schema,
+    SeriesInfo,
+    build_preview_names,
+    apply_post_conversion_rename,
+)
+from bids_manager.renaming.config import DEFAULT_SCHEMA_DIR, DERIVATIVES_PIPELINE_NAME
+
+
+def _touch(path: Path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("dummy")
+
+
+def create_fake_dataset(root: Path):
+    _touch(root / "sub-001" / "anat" / "sub-001_mprage.nii.gz")
+    _touch(root / "sub-001" / "anat" / "sub-001_mprage.json")
+    _touch(root / "sub-001" / "func" / "sub-001_fmri_rest.nii.gz")
+    _touch(root / "sub-001" / "func" / "sub-001_fmri_rest.json")
+    _touch(root / "sub-001" / "dwi" / "sub-001_ep2d_diff.nii.gz")
+    _touch(root / "sub-001" / "dwi" / "sub-001_ep2d_diff.json")
+    _touch(root / "sub-001" / "dwi" / "sub-001_ep2d_diff.bval")
+    _touch(root / "sub-001" / "dwi" / "sub-001_ep2d_diff.bvec")
+    for suffix in ["ADC", "FA", "TRACEW", "ColFA"]:
+        _touch(root / "sub-001" / "dwi" / f"sub-001_ep2d_diff_{suffix}.nii.gz")
+        _touch(root / "sub-001" / "dwi" / f"sub-001_ep2d_diff_{suffix}.json")
+    _touch(root / "sub-001" / "fmap" / "sub-001_echo-1.nii.gz")
+    _touch(root / "sub-001" / "fmap" / "sub-001_echo-2.nii.gz")
+    _touch(root / "sub-001" / "fmap" / "sub-001_fmap.nii.gz")
+
+
+def test_schema_renamer_end_to_end(tmp_path):
+    create_fake_dataset(tmp_path)
+    schema = load_bids_schema(DEFAULT_SCHEMA_DIR)
+    series = [
+        SeriesInfo("001", None, "T1w", "mprage", 1, {}),
+        SeriesInfo("001", None, "bold", "fmri_rest", 1, {}),
+        SeriesInfo("001", None, "dwi", "ep2d_diff", 1, {}),
+    ]
+    proposals = build_preview_names(series, schema)
+    rename_map = apply_post_conversion_rename(tmp_path, proposals)
+    assert (tmp_path / "sub-001" / "anat" / "sub-001_T1w.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "func" / "sub-001_task-rest_bold.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "dwi" / "sub-001_dwi.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "dwi" / "sub-001_dwi.bval").exists()
+    assert (tmp_path / "sub-001" / "dwi" / "sub-001_dwi.bvec").exists()
+    for suffix in ["ADC", "FA", "TRACEW", "ColFA"]:
+        out = tmp_path / "derivatives" / DERIVATIVES_PIPELINE_NAME / "sub-001" / "dwi" / f"sub-001_desc-{suffix}_dwi.nii.gz"
+        assert out.exists()
+    assert (tmp_path / "sub-001" / "fmap" / "sub-001_magnitude1.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "fmap" / "sub-001_magnitude2.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "fmap" / "sub-001_phasediff.nii.gz").exists()
+    rename_map2 = apply_post_conversion_rename(tmp_path, proposals)
+    assert rename_map2 == {}


### PR DESCRIPTION
## Summary
- add optional PyYAML dependency and new renaming module with schema-driven logic
- integrate preview and post-conversion rename into GUI
- normalize fieldmaps and move vendor DWI maps into derivatives
- include renaming package in distribution manifest

## Testing
- `python -m pytest tests/test_schema_renamer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb46b7b84832682f180a0d7139cfa