### PR TITLE
Improve schema-based BIDS naming and preview

### DIFF
--- a/tests/test_schema_renamer.py
+++ b/tests/test_schema_renamer.py
@@ -55,3 +55,19 @@ def test_schema_renamer_end_to_end(tmp_path):
     assert (tmp_path / "sub-001" / "fmap" / "sub-001_phasediff.nii.gz").exists()
     rename_map2 = apply_post_conversion_rename(tmp_path, proposals)
     assert rename_map2 == {}
+
+
+def test_duplicate_names_numbered(tmp_path):
+    schema = load_bids_schema(DEFAULT_SCHEMA_DIR)
+    _touch(tmp_path / "sub-001" / "anat" / "sub-001_orig1.nii.gz")
+    _touch(tmp_path / "sub-001" / "anat" / "sub-001_orig1.json")
+    _touch(tmp_path / "sub-001" / "anat" / "sub-001_orig2.nii.gz")
+    _touch(tmp_path / "sub-001" / "anat" / "sub-001_orig2.json")
+    series = [
+        SeriesInfo("001", None, "T1w", "mprage", 1, {"current_bids": "sub-001_orig1"}),
+        SeriesInfo("001", None, "T1w", "mprage", 1, {"current_bids": "sub-001_orig2"}),
+    ]
+    proposals = build_preview_names(series, schema)
+    rename_map = apply_post_conversion_rename(tmp_path, proposals)
+    assert (tmp_path / "sub-001" / "anat" / "sub-001_T1w.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "anat" / "sub-001_T1w(2).nii.gz").exists()


### PR DESCRIPTION
## Summary
- show proposed BIDS names beside sequences and display full path
- derive subject IDs from `BIDS_name` and preview original sequence names
- number duplicate BIDS outputs with `(2)`, `(3)` and rename DWI maps into derivatives

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beca8ba44c8326855804928012a185