### PR TITLE
Use explicit rep column for repeated series detection

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -88,39 +88,31 @@ def write_heuristic(df: pd.DataFrame, dst: Path) -> None:
     buf.append("}\n\n")
 
     # 3 ─ template keys ----------------------------------------------------
-    # Include series UID (or rep) in the key to handle repeated sequences
+    # Include series UID (or explicit ``rep``) in the key so repeated
+    # acquisitions map to distinct heuristic entries.
     seq2key: dict[tuple[str, str, str, str, str], str] = {}
     key_defs: list[tuple[str, str]] = []
 
-    rep_counts = (
-        df.groupby(["BIDS_name", "session", "sequence"], dropna=False)["sequence"].transform("count")
-    )
-    rep_index = (
-        df.groupby(["BIDS_name", "session", "sequence"], dropna=False).cumcount() + 1
-    )
-
     key_def_set = set()
-    for idx, row in df.iterrows():
+    for _, row in df.iterrows():
         ses_raw = row.get("session", "")
         ses = "" if pd.isna(ses_raw) else str(ses_raw).strip()
         folder = Path(str(row.get("source_folder", "."))).name
-        rep_num = rep_index.loc[idx]
         uid_field = str(row.get("series_uid", ""))
         bids = row["BIDS_name"]
         container = row.get("modality_bids", "misc") or "misc"
         stem = safe_stem(row["sequence"])
 
-        base_parts = [bids, ses, stem]
-        if rep_counts.loc[idx] > 1:
-            base_parts.append(f"rep-{rep_num}")
+        rep_raw = str(row.get("rep", "")).strip()
+        rep_tag = f"rep-{rep_raw}" if rep_raw and rep_raw not in {"0", "1"} else ""
+
+        base_parts = [p for p in [bids, ses, stem, rep_tag] if p]
         base = dedup_parts(*base_parts)
         path = "/".join(p for p in [bids, ses, container] if p)
         template = f"{path}/{base}"
 
-        key_parts = [bids, ses, stem]
-        if rep_counts.loc[idx] > 1:
-            key_parts.append(f"rep-{rep_num}")
-        key_var = "key_" + clean("_".join(p for p in key_parts if p))
+        key_parts = [p for p in [bids, ses, stem, rep_tag] if p]
+        key_var = "key_" + clean("_".join(key_parts))
         if key_var not in key_def_set:
             key_defs.append((key_var, template))
             key_def_set.add(key_var)

--- a/tests/test_schema_renamer.py
+++ b/tests/test_schema_renamer.py
@@ -65,7 +65,9 @@ def test_duplicate_names_numbered(tmp_path):
     _touch(tmp_path / "sub-001" / "anat" / "sub-001_orig2.json")
     series = [
         SeriesInfo("001", None, "T1w", "mprage", 1, {"current_bids": "sub-001_orig1"}),
-        SeriesInfo("001", None, "T1w", "mprage", 1, {"current_bids": "sub-001_orig2"}),
+        # Explicitly mark the second acquisition as repeat number 2 so that
+        # build_preview_names appends "(2)" instead of auto‑detecting repeats.
+        SeriesInfo("001", None, "T1w", "mprage", 2, {"current_bids": "sub-001_orig2"}),
     ]
     proposals = build_preview_names(series, schema)
     rename_map = apply_post_conversion_rename(tmp_path, proposals)


### PR DESCRIPTION
## Summary
- Stop inferring repeated sequences by name; rely solely on the TSV `rep` column when building preview names and heuristics
- Ensure heuristic builder embeds provided repetition numbers instead of re-counting sequences
- Update schema renamer tests to cover the new rep-driven logic

## Testing
- `PYTHONPATH=$PWD pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bed6ad95b08326a0860f66b8bce4f6