### PR TITLE
Improve run and task detection in renaming logic

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -157,7 +157,7 @@ def _compute_bids_preview(df, schema):
         rep = row.get("rep") or row.get("repeat") or 1
 
         extra = {}
-        for key in ("task", "acq", "run", "dir", "echo"):
+        for key in ("task", "task_hits", "acq", "run", "dir", "echo"):
             if row.get(key):
                 extra[key] = str(row.get(key))
 
@@ -2014,7 +2014,7 @@ class BIDSManager(QMainWindow):
             rep = int(rep_val) if rep_val else None
 
             extra: dict[str, str] = {}
-            for key in ("task", "acq", "run", "dir", "echo"):
+            for key in ("task", "task_hits", "acq", "run", "dir", "echo"):
                 if row.get(key):
                     extra[key] = str(row.get(key))
 


### PR DESCRIPTION
## Summary
- preserve run numbers in proposed BIDS names and clean session prefixes
- honor `task_hits` and expand task keyword detection
- propagate task hints through GUI/TSV helpers
- keep normalized modality for consistent tables
- add tests for fieldmap run handling and task hits

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2c3dbf9948326b411d2c7e4ca4e10