### PR TITLE
Avoid auto-generated acquisition labels

### DIFF
--- a/bids_manager/renaming/schema_renamer.py
+++ b/bids_manager/renaming/schema_renamer.py
@@ -362,15 +362,13 @@ def propose_bids_basename(series: SeriesInfo, schema: SchemaInfo) -> Tuple[str, 
         # Force suffix used later to dwi
         suffix = "dwi"
     else:
-        # For non-derivatives, add acquisition tag if we need uniqueness
-        # This handles cases where different sequences would otherwise get same name
+        # For non-derivatives, only include an acquisition label if one was
+        # explicitly provided. Previously, the sequence text was used as a
+        # fallback to guarantee uniqueness, which produced long
+        # ``acq-<pattern>`` tokens. These were confusing and not BIDS
+        # recommended, so we now omit ``acq`` unless the caller supplies it.
         acq = series.extra.get("acq") if series.extra else None
-        if not acq and datatype not in ("anat", "fmap"):  # Don't auto-add acq for anatomy/fieldmaps
-            # Use sequence as acquisition for uniqueness if no explicit acq
-            acq_token = _sanitize_token(clean_sequence)[:32]
-            if acq_token and len(acq_token) > 0:
-                parts.append(f"acq-{acq_token}")
-        elif acq:
+        if acq:
             acq = _sanitize_token(acq)
             if acq:
                 parts.append(f"acq-{acq}")

--- a/tests/test_schema_renamer.py
+++ b/tests/test_schema_renamer.py
@@ -43,18 +43,10 @@ def test_schema_renamer_end_to_end(tmp_path):
     proposals = build_preview_names(series, schema)
     rename_map = apply_post_conversion_rename(tmp_path, proposals)
     assert (tmp_path / "sub-001" / "anat" / "sub-001_T1w.nii.gz").exists()
-    assert (
-        tmp_path / "sub-001" / "func" / "sub-001_task-rest_acq-fmrirest_bold.nii.gz"
-    ).exists()
-    assert (
-        tmp_path / "sub-001" / "dwi" / "sub-001_acq-ep2ddiff_dwi.nii.gz"
-    ).exists()
-    assert (
-        tmp_path / "sub-001" / "dwi" / "sub-001_acq-ep2ddiff_dwi.bval"
-    ).exists()
-    assert (
-        tmp_path / "sub-001" / "dwi" / "sub-001_acq-ep2ddiff_dwi.bvec"
-    ).exists()
+    assert (tmp_path / "sub-001" / "func" / "sub-001_task-rest_bold.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "dwi" / "sub-001_dwi.nii.gz").exists()
+    assert (tmp_path / "sub-001" / "dwi" / "sub-001_dwi.bval").exists()
+    assert (tmp_path / "sub-001" / "dwi" / "sub-001_dwi.bvec").exists()
     for suffix in ["ADC", "FA", "TRACEW", "ColFA"]:
         out = tmp_path / "derivatives" / DERIVATIVES_PIPELINE_NAME / "sub-001" / "dwi" / f"sub-001_desc-{suffix}_dwi.nii.gz"
         assert out.exists()
@@ -113,4 +105,4 @@ def test_fieldmap_runs_and_task_hits(tmp_path):
         "sub-001_run-02_phasediff",
     ]
     # Task hit "custom" should be used
-    assert task_base == "sub-001_task-custom_acq-customsequence_bold"
+    assert task_base == "sub-001_task-custom_bold"


### PR DESCRIPTION
## Summary
- stop adding `acq-<pattern>` when no acquisition was specified
- update renamer tests for new naming scheme

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2d72d7c34832687e4034d5cc21ff7