### PR TITLE
Handle SBRef and physio naming

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -6,8 +6,7 @@ Simple heuristic that:
 1. **Keeps every sequence**, including SBRef.
 2. **Uses the raw SeriesDescription** (cleaned) as the filename stem – no
    added `rep-*`, task, or echo logic.
-3. Skips only modalities listed in `SKIP_BY_DEFAULT` (`report`,
-   `physio`, `refscan`).
+3. Skips only modalities listed in `SKIP_BY_DEFAULT` (`report`, `physio`).
 """
 
 from __future__ import annotations
@@ -37,7 +36,7 @@ except Exception:
 # -----------------------------------------------------------------------------
 # Configuration
 # -----------------------------------------------------------------------------
-SKIP_BY_DEFAULT = {"report", "physio", "refscan"}
+SKIP_BY_DEFAULT = {"report", "physio"}
 
 # -----------------------------------------------------------------------------
 # Helper functions

--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -9,7 +9,7 @@ Why you want this
 -----------------
 * Lets you review **all** SeriesDescriptions, subjects, sessions and file counts
   before converting anything.
-* Column `include` defaults to 1 except for scout/report/physlog sequences,
+* Column `include` defaults to 1 except for scout/report/physio sequences,
   which start at 0 so they are skipped by default.
 * Generated table is the single source of truth you feed into a helper script
   that writes the HeuDiConv heuristic.
@@ -22,7 +22,7 @@ session        – `ses-<label>` if exactly one unique session tag is present in
                  that folder, otherwise blank
 source_folder  – relative path from the DICOM root to the folder containing the
                  series
-include        – defaults to 1 but scout/report/physlog rows start at 0
+include        – defaults to 1 but scout/report/physio rows start at 0
 sequence       – original SeriesDescription
 series_uid     – DICOM SeriesInstanceUID identifying a specific acquisition
 rep            – 1, 2, … if multiple SeriesInstanceUIDs share the same description
@@ -98,10 +98,15 @@ BIDS_PATTERNS = {
     "PDw"    : ("gre-nm", "gre_nm"),
     "scout"  : ("localizer", "scout"),
     "report" : ("phoenixzipreport", "phoenix document", ".pdf", "report"),
-    "refscan": ("type-ref", "reference", "refscan"),
     # functional
     "bold"   : ("fmri", "bold", "task-"),
-    "SBRef"  : ("sbref",),
+    "SBRef"  : (
+        "sbref",
+        "type-ref",
+        "reference",
+        "refscan",
+        "ref",
+    ),
     # diffusion
     "dwi"    : ("dti", "dwi", "diff"),
     # field maps
@@ -216,7 +221,7 @@ def classify_fieldmap_type(img_list: list) -> str:
 BIDS_CONTAINER = {
     "T1w":"anat", "T2w":"anat", "FLAIR":"anat",
     "MTw":"anat", "PDw":"anat",
-    "scout":"anat", "report":"anat", "refscan":"anat",
+    "scout":"anat", "report":"anat",
     "bold":"func", "SBRef":"func",
     "dwi":"dwi",
     "dwi_derivative":"derivatives",  # DWI derivatives go to derivatives folder
@@ -380,7 +385,11 @@ def scan_dicoms_long(
                 fine_mod = mods[subj_key][folder][(series, uid)]
                 img3 = imgtypes[subj_key][folder].get((series, uid), "")
                 include = 1
-                if fine_mod in {"scout", "report"} or "physlog" in series.lower():
+                # Skip scout, report, and physiological recordings by default so
+                # they don't get processed unless explicitly enabled. Also
+                # catch legacy "physlog" labels which sometimes appear in the
+                # SeriesDescription.
+                if fine_mod in {"scout", "report", "physio"} or "physlog" in series.lower():
                     include = 0
                 # Do not consider image type when counting scout duplicates
                 rep_key = series if fine_mod == "scout" else (series, img3)

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -92,6 +92,7 @@ from .renaming.schema_renamer import (
     SeriesInfo,
     build_preview_names,
     apply_post_conversion_rename,
+    compose_proposed_name,
 )
 try:
     import psutil
@@ -168,6 +169,8 @@ def _compute_bids_preview(df, schema):
     for (series, dt, base), idx in zip(proposals, idxs):
         out[idx] = (dt, base)
     return out
+
+
 
 # ---- basic logging config ----
 logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
@@ -1823,7 +1826,9 @@ class BIDSManager(QMainWindow):
         df["proposed_datatype"] = [preview_map.get(i, ("", ""))[0] for i in df.index]
         df["proposed_basename"] = [preview_map.get(i, ("", ""))[1] for i in df.index]
         df["Proposed BIDS name"] = df.apply(
-            lambda r: (f"{r['proposed_datatype']}/{r['proposed_basename']}.nii.gz") if r["proposed_basename"] else "",
+            lambda r: compose_proposed_name(
+                r.get("modality", ""), r["proposed_datatype"], r["proposed_basename"]
+            ),
             axis=1,
         )
         self.inventory_df = df

--- a/bids_manager/renaming/schema_renamer.py
+++ b/bids_manager/renaming/schema_renamer.py
@@ -196,6 +196,18 @@ def _infer_dwi_acq_dir(sequence: str) -> Tuple[Optional[str], Optional[str]]:
     return acq, direction
 
 
+def compose_proposed_name(modality: str, datatype: str, basename: str) -> str:
+    """Return a full proposed filename with an appropriate extension.
+
+    Physiological recordings are stored as TSV files, whereas imaging data
+    defaults to NIfTI. The JSON sidecar is implied to share the same stem.
+    """
+    if not basename:
+        return ""
+    ext = ".tsv" if modality.lower() == "physio" else ".nii.gz"
+    return f"{datatype}/{basename}{ext}"
+
+
 def _replace_stem_keep_ext(src: Path, new_basename: str) -> Path:
     ext = _resolve_ext(src.name)
     return src.with_name(f"{new_basename}{ext}")

--- a/tests/test_proposed_names.py
+++ b/tests/test_proposed_names.py
@@ -1,0 +1,14 @@
+from bids_manager.renaming.schema_renamer import compose_proposed_name
+
+def test_physio_uses_tsv_extension():
+    assert (
+        compose_proposed_name("physio", "func", "sub-001_task-rest_physio")
+        == "func/sub-001_task-rest_physio.tsv"
+    )
+
+
+def test_images_use_nifti_extension():
+    assert (
+        compose_proposed_name("bold", "func", "sub-001_task-rest_bold")
+        == "func/sub-001_task-rest_bold.nii.gz"
+    )

--- a/tests/test_sequence_dictionary.py
+++ b/tests/test_sequence_dictionary.py
@@ -1,0 +1,6 @@
+from bids_manager import dicom_inventory
+
+
+def test_sbref_patterns_cover_old_refscan():
+    for seq in ["type-ref", "reference", "refscan", "ref"]:
+        assert dicom_inventory.guess_modality(seq) == "SBRef"


### PR DESCRIPTION
## Summary
- unify refscan handling under SBRef and add "ref" pattern
- ensure physio modalities default to .tsv in proposed names
- skip physio series by default and adjust heuristic skip list

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3df73cf448326bf9f2de327f1e522