### PR TITLE
Improve sequence dictionary and physio naming

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -6,8 +6,7 @@ Simple heuristic that:
 1. **Keeps every sequence**, including SBRef.
 2. **Uses the raw SeriesDescription** (cleaned) as the filename stem – no
    added `rep-*`, task, or echo logic.
-3. Skips only modalities listed in `SKIP_BY_DEFAULT` (`report`,
-   `physio`, `refscan`).
+3. Skips only modalities listed in `SKIP_BY_DEFAULT` (`report`, `physio`).
 """
 
 from __future__ import annotations
@@ -37,7 +36,7 @@ except Exception:
 # -----------------------------------------------------------------------------
 # Configuration
 # -----------------------------------------------------------------------------
-SKIP_BY_DEFAULT = {"report", "physio", "refscan"}
+SKIP_BY_DEFAULT = {"report", "physio"}
 
 # -----------------------------------------------------------------------------
 # Helper functions

--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -9,8 +9,8 @@ Why you want this
 -----------------
 * Lets you review **all** SeriesDescriptions, subjects, sessions and file counts
   before converting anything.
-* Column `include` defaults to 1 except for scout/report/physlog sequences,
-  which start at 0 so they are skipped by default.
+* Column `include` defaults to 1 except for scout/report/physlog/physio
+  sequences, which start at 0 so they are skipped by default.
 * Generated table is the single source of truth you feed into a helper script
   that writes the HeuDiConv heuristic.
 
@@ -22,7 +22,7 @@ session        – `ses-<label>` if exactly one unique session tag is present in
                  that folder, otherwise blank
 source_folder  – relative path from the DICOM root to the folder containing the
                  series
-include        – defaults to 1 but scout/report/physlog rows start at 0
+include        – defaults to 1 but scout/report/physlog/physio rows start at 0
 sequence       – original SeriesDescription
 series_uid     – DICOM SeriesInstanceUID identifying a specific acquisition
 rep            – 1, 2, … if multiple SeriesInstanceUIDs share the same description
@@ -31,6 +31,9 @@ modality       – fine label inferred from patterns (T1w, bold, dwi, …)
 modality_bids  – top-level container (anat, func, dwi, fmap) derived from
                  *modality*
 n_files        – number of DICOM files (.dcm or .ima) with that SeriesDescription
+proposed_datatype – suggested BIDS top-level folder (anat, func, etc.)
+proposed_basename – recommended filename stem without extension
+Proposed BIDS name – full `<datatype>/<basename><ext>` suggestion
 GivenName … StudyDescription – demographics copied from the first header seen
 """
 
@@ -98,10 +101,9 @@ BIDS_PATTERNS = {
     "PDw"    : ("gre-nm", "gre_nm"),
     "scout"  : ("localizer", "scout"),
     "report" : ("phoenixzipreport", "phoenix document", ".pdf", "report"),
-    "refscan": ("type-ref", "reference", "refscan"),
     # functional
     "bold"   : ("fmri", "bold", "task-"),
-    "SBRef"  : ("sbref",),
+    "SBRef"  : ("sbref", "type-ref", "reference", "refscan", "ref"),
     # diffusion
     "dwi"    : ("dti", "dwi", "diff"),
     # field maps
@@ -125,8 +127,15 @@ DEFAULT_BIDS_PATTERNS = {m: tuple(pats) for m, pats in BIDS_PATTERNS.items()}
 
 
 def load_sequence_dictionary() -> None:
-    """Load user-modified sequence patterns from :data:`SEQ_DICT_FILE`."""
+    """Load user-modified sequence patterns from :data:`SEQ_DICT_FILE`.
+
+    When no custom dictionary exists, this resets :data:`BIDS_PATTERNS` to the
+    built-in defaults so the application always has a complete set of
+    detection rules without requiring the user to manually restore them.
+    """
     global BIDS_PATTERNS
+    # Start with bundled defaults in case the preference file is missing
+    BIDS_PATTERNS = {m: tuple(pats) for m, pats in DEFAULT_BIDS_PATTERNS.items()}
     if not SEQ_DICT_FILE.exists():
         return
     try:
@@ -216,8 +225,8 @@ def classify_fieldmap_type(img_list: list) -> str:
 BIDS_CONTAINER = {
     "T1w":"anat", "T2w":"anat", "FLAIR":"anat",
     "MTw":"anat", "PDw":"anat",
-    "scout":"anat", "report":"anat", "refscan":"anat",
-    "bold":"func", "SBRef":"func",
+    "scout":"anat", "report":"anat",
+    "bold":"func", "SBRef":"func", "physio":"func",
     "dwi":"dwi",
     "dwi_derivative":"derivatives",  # DWI derivatives go to derivatives folder
     "fmap":"fmap",
@@ -380,7 +389,7 @@ def scan_dicoms_long(
                 fine_mod = mods[subj_key][folder][(series, uid)]
                 img3 = imgtypes[subj_key][folder].get((series, uid), "")
                 include = 1
-                if fine_mod in {"scout", "report"} or "physlog" in series.lower():
+                if fine_mod in {"scout", "report", "physio"} or "physlog" in series.lower():
                     include = 0
                 # Do not consider image type when counting scout duplicates
                 rep_key = series if fine_mod == "scout" else (series, img3)
@@ -466,6 +475,53 @@ def scan_dicoms_long(
         fmap_df.loc[~repeat_mask, "rep"] = ""
 
         df = pd.concat([df[~fmap_mask], fmap_df], ignore_index=True, sort=False)
+
+    # --------------------------------------------------------------
+    # Generate proposed BIDS names using the renamer's helper logic
+    # --------------------------------------------------------------
+    try:
+        from .renaming.schema_renamer import (
+            load_bids_schema,
+            SeriesInfo,
+            build_preview_names,
+        )
+        from .renaming.config import DEFAULT_SCHEMA_DIR
+
+        schema = load_bids_schema(DEFAULT_SCHEMA_DIR)
+        series_info = []
+        for _, row in df.iterrows():
+            subj = str(row["BIDS_name"])
+            if subj.lower().startswith("sub-"):
+                subj = subj[4:]
+            rep = row["rep"] if str(row.get("rep", "")).isdigit() else 1
+            series_info.append(
+                SeriesInfo(
+                    subj,
+                    row.get("session") or None,
+                    str(row.get("modality", "")),
+                    str(row.get("sequence", "")),
+                    int(rep),
+                    {},
+                )
+            )
+
+        proposals = build_preview_names(series_info, schema)
+        df["proposed_datatype"] = [dt for (_, dt, _) in proposals]
+        df["proposed_basename"] = [base for (_, _, base) in proposals]
+
+        def _ext(mod: str) -> str:
+            return ".tsv" if str(mod).lower() == "physio" else ".nii.gz"
+
+        df["Proposed BIDS name"] = [
+            f"{dt}/{base}{_ext(mod)}" if base else ""
+            for dt, base, mod in zip(
+                df["proposed_datatype"], df["proposed_basename"], df["modality"]
+            )
+        ]
+    except Exception:
+        df["proposed_datatype"] = ""
+        df["proposed_basename"] = ""
+        df["Proposed BIDS name"] = ""
 
     df.sort_values(["StudyDescription", "BIDS_name"], inplace=True)
 

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -1819,11 +1819,24 @@ class BIDSManager(QMainWindow):
         if not self.tsv_path or not os.path.isfile(self.tsv_path):
             return
         df = pd.read_csv(self.tsv_path, sep="\t", keep_default_na=False)
-        preview_map = _compute_bids_preview(df, self._schema)
-        df["proposed_datatype"] = [preview_map.get(i, ("", ""))[0] for i in df.index]
-        df["proposed_basename"] = [preview_map.get(i, ("", ""))[1] for i in df.index]
+
+        if "proposed_datatype" not in df.columns or "proposed_basename" not in df.columns:
+            preview_map = _compute_bids_preview(df, self._schema)
+            df["proposed_datatype"] = [preview_map.get(i, ("", ""))[0] for i in df.index]
+            df["proposed_basename"] = [preview_map.get(i, ("", ""))[1] for i in df.index]
+        else:
+            df["proposed_datatype"] = df["proposed_datatype"].fillna("")
+            df["proposed_basename"] = df["proposed_basename"].fillna("")
+
+        def _ext(mod: str) -> str:
+            return ".tsv" if str(mod).lower() == "physio" else ".nii.gz"
+
         df["Proposed BIDS name"] = df.apply(
-            lambda r: (f"{r['proposed_datatype']}/{r['proposed_basename']}.nii.gz") if r["proposed_basename"] else "",
+            lambda r: (
+                f"{r['proposed_datatype']}/{r['proposed_basename']}{_ext(r['modality'])}"
+                if r["proposed_basename"]
+                else ""
+            ),
             axis=1,
         )
         self.inventory_df = df
@@ -2430,6 +2443,32 @@ class BIDSManager(QMainWindow):
                     self.row_info[i]['mod'] = mod
                     self.row_info[i]['modb'] = modb
             self._rebuild_lookup_maps()
+
+            # Recompute proposed names to reflect the updated dictionary
+            if hasattr(self, "inventory_df"):
+                preview_map = _compute_bids_preview(self.inventory_df, self._schema)
+                self.inventory_df["proposed_datatype"] = [
+                    preview_map.get(i, ("", ""))[0] for i in self.inventory_df.index
+                ]
+                self.inventory_df["proposed_basename"] = [
+                    preview_map.get(i, ("", ""))[1] for i in self.inventory_df.index
+                ]
+
+                def _ext(mod: str) -> str:
+                    return ".tsv" if str(mod).lower() == "physio" else ".nii.gz"
+
+                self.inventory_df["Proposed BIDS name"] = self.inventory_df.apply(
+                    lambda r: (
+                        f"{r['proposed_datatype']}/{r['proposed_basename']}{_ext(r['modality'])}"
+                        if r["proposed_basename"]
+                        else ""
+                    ),
+                    axis=1,
+                )
+                for i in range(self.mapping_table.rowCount()):
+                    self.mapping_table.setItem(
+                        i, 7, QTableWidgetItem(self.inventory_df.at[i, "Proposed BIDS name"])
+                    )
             QTimer.singleShot(0, self.populateModalitiesTree)
             QTimer.singleShot(0, self.populateSpecificTree)
 

--- a/bids_manager/renaming/schema_renamer.py
+++ b/bids_manager/renaming/schema_renamer.py
@@ -332,6 +332,8 @@ def _choose_datatype(suffix: str, schema: SchemaInfo) -> str:
     
     dts = schema.suffix_to_datatypes.get(suffix)
     if dts:
+        if suffix == "physio" and "func" in dts:
+            return "func"
         pref = ("anat", "func", "dwi", "fmap", "perf", "pet", "meg", "eeg", "ieeg")
         for p in pref:
             if p in dts:
@@ -339,7 +341,7 @@ def _choose_datatype(suffix: str, schema: SchemaInfo) -> str:
         return dts[0]
     return {
         "T1w": "anat", "T2w": "anat", "FLAIR": "anat", "T2star": "anat", "PD": "anat",
-        "bold": "func", "sbref": "func", "dwi": "dwi",
+        "bold": "func", "sbref": "func", "physio": "func", "dwi": "dwi",
         "phasediff": "fmap", "fieldmap": "fmap", "magnitude1": "fmap", "magnitude2": "fmap", "epi": "fmap",
     }.get(suffix, "misc")
 


### PR DESCRIPTION
## Summary
- merge legacy refscan patterns into SBRef and always load default sequence dictionary when user overrides are absent
- generate and persist proposed BIDS names during inventory creation with correct physio extensions
- skip physio series by default and update GUI proposal handling and datatype inference accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3e89d0a8083269303270469860675