### PR TITLE
Handle SBRef and physio naming

### DIFF
--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -6,8 +6,7 @@ Simple heuristic that:
 1. **Keeps every sequence**, including SBRef.
 2. **Uses the raw SeriesDescription** (cleaned) as the filename stem – no
    added `rep-*`, task, or echo logic.
-3. Skips only modalities listed in `SKIP_BY_DEFAULT` (`report`,
-   `physio`, `refscan`).
+3. Skips only modalities listed in `SKIP_BY_DEFAULT` (`report`, `physio`).
 """
 
 from __future__ import annotations
@@ -37,7 +36,7 @@ except Exception:
 # -----------------------------------------------------------------------------
 # Configuration
 # -----------------------------------------------------------------------------
-SKIP_BY_DEFAULT = {"report", "physio", "refscan"}
+SKIP_BY_DEFAULT = {"report", "physio"}
 
 # -----------------------------------------------------------------------------
 # Helper functions

--- a/bids_manager/renaming/schema_renamer.py
+++ b/bids_manager/renaming/schema_renamer.py
@@ -339,7 +339,7 @@ def _choose_datatype(suffix: str, schema: SchemaInfo) -> str:
         return dts[0]
     return {
         "T1w": "anat", "T2w": "anat", "FLAIR": "anat", "T2star": "anat", "PD": "anat",
-        "bold": "func", "sbref": "func", "dwi": "dwi",
+        "bold": "func", "sbref": "func", "physio": "func", "dwi": "dwi",
         "phasediff": "fmap", "fieldmap": "fmap", "magnitude1": "fmap", "magnitude2": "fmap", "epi": "fmap",
     }.get(suffix, "misc")
 


### PR DESCRIPTION
## Summary
- recognise SBRef sequences with additional ref/refscan patterns and prioritise physio and SBRef over bold detection
- map physio data to func and store proposed BIDS names (with correct extensions) in the scan inventory
- ensure the GUI and naming helpers output _sbref and _physio paths, leaving refscan deprecated

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3ee29dc508326a4d6f40c4428a6bb