### PR TITLE
Ensure physio files mirror bold task/run naming

### DIFF
--- a/bids_manager/renaming/schema_renamer.py
+++ b/bids_manager/renaming/schema_renamer.py
@@ -383,7 +383,12 @@ def propose_bids_basename(series: SeriesInfo, schema: SchemaInfo) -> Tuple[str, 
     run_number = _extract_run_number(series.sequence)
     clean_sequence = _strip_run_tokens(series.sequence)
 
-    if "task" in required or suffix in ("bold", "sbref"):
+    # ``task`` labels are mandatory for some suffixes (as per the schema
+    # requirements) and also desirable for functional reference scans and
+    # physiological recordings so that supporting files share the same base
+    # name as their associated BOLD runs.  Treat ``physio`` like ``bold`` and
+    # ``sbref`` so that it inherits task/run context from the sequence text.
+    if "task" in required or suffix in ("bold", "sbref", "physio"):
         task_hint = series.extra.get("task") if series.extra else None
 
         # ``task_hits`` is an optional list of keywords extracted by the GUI

--- a/tests/test_schema_renamer.py
+++ b/tests/test_schema_renamer.py
@@ -154,6 +154,22 @@ def test_sbref_and_physio_detection():
     assert base_phys.endswith("_physio")
 
 
+def test_physio_naming_preserves_task_and_run():
+    """Physio recordings should share task/run labels with their BOLD runs."""
+
+    schema = load_bids_schema(DEFAULT_SCHEMA_DIR)
+
+    bold = SeriesInfo("001", None, "bold", "task-two_run-01_bold", None, {})
+    phys = SeriesInfo("001", None, "physio", "task-two_run-01_physio", None, {})
+
+    proposals = build_preview_names([bold, phys], schema)
+
+    bases = {base for (_, _, base) in proposals}
+
+    assert "sub-001_task-two_run-01_bold" in bases
+    assert "sub-001_task-two_run-01_physio" in bases
+
+
 def test_guess_modality_prefers_sbref_and_physio():
     """When sequences contain bold tokens, SBRef/physio patterns win."""
 


### PR DESCRIPTION
## Summary
- allow physiolog recordings to inherit task/run labels just like BOLD and SBRef
- verify physio basenames use task and run context

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c3f32b8b6c8326a74dda0d1954e793