### PR TITLE
Add DICOM metadata deep mining utility

### DIFF
--- a/bids_manager/dicom_metadata_deep_mining.py
+++ b/bids_manager/dicom_metadata_deep_mining.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""DICOM metadata deep mining utility.
+
+This script recursively scans a directory tree for DICOM files and writes
+all metadata fields exposed by :mod:`pydicom` into a TSV table. Each row
+in the output corresponds to a single DICOM file, and each column
+represents a metadata field encountered across the dataset.
+
+It complements :mod:`dicom_inventory` by providing an exhaustive view of
+the headers rather than a curated subset.
+
+Example
+-------
+Run from the command line using either the entry point or the module::
+
+    dicom-metadata-deep-mining /path/to/dicoms output.tsv
+
+    python -m bids_manager.dicom_metadata_deep_mining /path/to/dicoms output.tsv
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+import pydicom
+from pydicom.multival import MultiValue
+
+# Reuse helper from dicom_inventory to recognise DICOM files
+from bids_manager.dicom_inventory import is_dicom_file
+
+
+def _ds_to_dict(ds: pydicom.Dataset) -> Dict[str, str]:
+    """Convert a :class:`pydicom.Dataset` into a flat dictionary.
+
+    Nested sequences are flattened using dotted keys (e.g. ``Seq[0].Field``).
+    Values are coerced to strings suitable for TSV output.
+    """
+
+    info: Dict[str, str] = {}
+    for elem in ds:
+        key = elem.keyword or str(elem.tag)
+        value = elem.value
+        if isinstance(value, MultiValue):
+            value = ';'.join(str(v) for v in value)
+        elif isinstance(value, (bytes, bytearray)):
+            value = value.hex()
+        elif isinstance(value, pydicom.dataset.Dataset):
+            nested = _ds_to_dict(value)
+            for k, v in nested.items():
+                info[f"{key}.{k}"] = v
+            continue
+        elif isinstance(value, pydicom.sequence.Sequence):
+            for i, item in enumerate(value):
+                nested = _ds_to_dict(item)
+                for k, v in nested.items():
+                    info[f"{key}[{i}].{k}"] = v
+            continue
+        info[key] = str(value)
+    return info
+
+
+def scan_dicoms_all_fields(dicom_dir: str, output_tsv: str | None = None) -> pd.DataFrame:
+    """Scan *dicom_dir* recursively and extract all metadata fields."""
+
+    rows: List[Dict[str, str]] = []
+    all_keys: set[str] = set()
+    root = Path(dicom_dir)
+
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            fpath = Path(dirpath) / name
+            if not is_dicom_file(str(fpath)):
+                continue
+            try:
+                ds = pydicom.dcmread(str(fpath), stop_before_pixels=True, force=True)
+            except Exception:
+                continue
+            meta = _ds_to_dict(ds)
+            record = {"file": fpath.relative_to(root).as_posix(), **meta}
+            rows.append(record)
+            all_keys.update(meta.keys())
+
+    df = pd.DataFrame(rows)
+    columns = ['file'] + sorted(all_keys)
+    df = df.reindex(columns=columns)
+    if output_tsv:
+        df.to_csv(output_tsv, sep='	', index=False)
+    return df
+
+
+def main(argv: List[str] | None = None) -> None:
+    """CLI entry point."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Extract all DICOM metadata fields into a TSV table'
+    )
+    parser.add_argument('dicom_dir', help='Directory containing DICOM files')
+    parser.add_argument('output_tsv', help='Path of the TSV file to create')
+    args = parser.parse_args(argv)
+
+    scan_dicoms_all_fields(args.dicom_dir, args.output_tsv)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -354,6 +354,7 @@ class BIDSManager(QMainWindow):
         # Async process handles for inventory and conversion steps
         self.inventory_process = None  # QProcess for dicom_inventory
         self.conv_process = None       # QProcess for the conversion pipeline
+        self.deep_process = None       # QProcess for metadata deep mining
         self.conv_stage = 0            # Tracks which step of the pipeline ran
         self.heurs_to_rename = []      # List of heuristics pending rename
 
@@ -1274,6 +1275,10 @@ class BIDSManager(QMainWindow):
         ignore_act = QAction("Edit .bidsignore…", self)
         ignore_act.triggered.connect(self.launchBidsIgnore)
         tools_menu.addAction(ignore_act)
+
+        deep_act = QAction("DICOM Metadata Deep Mining…", self)
+        deep_act.triggered.connect(self.launchDicomDeepMining)
+        tools_menu.addAction(deep_act)
         edit_layout.addWidget(menu)
 
         # Splitter between left (tree & stats) and right (metadata)
@@ -2889,6 +2894,40 @@ class BIDSManager(QMainWindow):
         dlg = BidsIgnoreDialog(self, self.bids_root)
         dlg.exec_()
 
+    def launchDicomDeepMining(self):
+        """Open dialog to run the DICOM metadata deep mining tool."""
+        dlg = DicomDeepMiningDialog(self)
+        if dlg.exec_() != QDialog.Accepted:
+            return
+        dicom_dir = dlg.dicom_dir
+        out_dir = dlg.output_dir
+        fname = dlg.file_name
+        if not dicom_dir or not out_dir or not fname:
+            QMessageBox.warning(self, "Deep Mining", "Please select all fields")
+            return
+        out_path = str(Path(out_dir) / fname)
+        if self.deep_process and self.deep_process.state() != QProcess.NotRunning:
+            QMessageBox.warning(self, "Deep Mining", "Process already running")
+            return
+        self.deep_process = QProcess(self)
+        self.deep_process.setProcessChannelMode(QProcess.ForwardedChannels)
+        self.deep_process.finished.connect(
+            lambda code, _status: QMessageBox.information(
+                self,
+                "Deep Mining",
+                "Completed" if code == 0 else f"Process exited with code {code}",
+            )
+        )
+        self.deep_process.start(
+            sys.executable,
+            [
+                "-m",
+                "bids_manager.dicom_metadata_deep_mining",
+                dicom_dir,
+                out_path,
+            ],
+        )
+
 
 class RemapDialog(QDialog):
     """
@@ -3693,6 +3732,62 @@ class BidsIgnoreDialog(QDialog):
         self.ignore_file.write_text("\n".join(sorted(self.entries)) + "\n")
         QMessageBox.information(self, "Saved", f"Updated {self.ignore_file}")
         self.accept()
+
+
+class DicomDeepMiningDialog(QDialog):
+    """Dialog to configure and launch metadata deep mining."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.setWindowTitle("DICOM Metadata Deep Mining")
+        layout = QGridLayout(self)
+
+        layout.addWidget(QLabel("Raw data Dir:"), 0, 0)
+        self.dicom_edit = QLineEdit()
+        self.dicom_edit.setReadOnly(True)
+        btn_dicom = QPushButton("Browse…")
+        btn_dicom.clicked.connect(self._choose_dicom)
+        layout.addWidget(self.dicom_edit, 0, 1)
+        layout.addWidget(btn_dicom, 0, 2)
+
+        layout.addWidget(QLabel("Output Dir:"), 1, 0)
+        self.out_edit = QLineEdit()
+        self.out_edit.setReadOnly(True)
+        btn_out = QPushButton("Browse…")
+        btn_out.clicked.connect(self._choose_out)
+        layout.addWidget(self.out_edit, 1, 1)
+        layout.addWidget(btn_out, 1, 2)
+
+        layout.addWidget(QLabel("File Name:"), 2, 0)
+        self.name_edit = QLineEdit("metadata.tsv")
+        layout.addWidget(self.name_edit, 2, 1, 1, 2)
+
+        btn_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        btn_box.accepted.connect(self.accept)
+        btn_box.rejected.connect(self.reject)
+        layout.addWidget(btn_box, 3, 0, 1, 3)
+
+    def _choose_dicom(self):
+        d = QFileDialog.getExistingDirectory(self, "Select DICOM directory")
+        if d:
+            self.dicom_edit.setText(d)
+
+    def _choose_out(self):
+        d = QFileDialog.getExistingDirectory(self, "Select output directory")
+        if d:
+            self.out_edit.setText(d)
+
+    @property
+    def dicom_dir(self) -> str:
+        return self.dicom_edit.text()
+
+    @property
+    def output_dir(self) -> str:
+        return self.out_edit.text()
+
+    @property
+    def file_name(self) -> str:
+        return self.name_edit.text()
 
 
 class MetadataViewer(QWidget):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Tracker = "https://github.com/ANCPLabOldenburg/BIDS-Manager/issues"
 [project.scripts]
 bids-manager = "bids_manager.gui:main"
 dicom-inventory = "bids_manager.dicom_inventory:main"
+dicom-metadata-deep-mining = "bids_manager.dicom_metadata_deep_mining:main"
 build-heuristic = "bids_manager.build_heuristic_from_tsv:main"
 run-heudiconv = "bids_manager.run_heudiconv_from_heuristic:main"
 post-conv-renamer = "bids_manager.post_conv_renamer:main"


### PR DESCRIPTION
## Summary
- add `dicom_metadata_deep_mining` CLI to dump all DICOM header fields to TSV
- expose new deep mining option in GUI Tools menu
- wire new command as project script entry point

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c40a5a786c83268a09366489f68a33