### PR TITLE
Fix renaming helpers import fallback

### DIFF
--- a/bids_manager/schema_config.py
+++ b/bids_manager/schema_config.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from ._renaming_loader import load_module
+try:
+    from ._renaming_loader import load_module
+except ImportError:  # pragma: no cover - fallback for direct execution
+    # See ``schema_renamer`` for the rationale.  When the package is not
+    # initialised (e.g. running helper scripts from a source checkout) the
+    # relative import fails, so fall back to the plain module import.
+    from _renaming_loader import load_module  # type: ignore
 
 _config = load_module("config")
 

--- a/bids_manager/schema_renamer.py
+++ b/bids_manager/schema_renamer.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-from ._renaming_loader import load_module
+try:
+    from ._renaming_loader import load_module
+except ImportError:  # pragma: no cover - fallback for direct execution
+    # When this module is imported from a checkout via ``python path/to/script``
+    # the ``bids_manager`` package is not initialised, so relative imports fail.
+    # Importing the helper directly keeps the lightweight wrappers usable in
+    # that scenario (e.g. when ``build_heuristic_from_tsv`` falls back to
+    # absolute imports during development).
+    from _renaming_loader import load_module  # type: ignore
 
 _impl = load_module("schema_renamer")
 


### PR DESCRIPTION
## Summary
- allow the schema wrapper modules to fall back to absolute imports when the bids_manager package is not initialised

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68cab2ac0e488326a1e12fd65c58a9ac