### PR TITLE
Fix volume mesh controls shrinking plot and declare mesh dependency

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -3778,6 +3778,9 @@ class Volume3DDialog(QDialog):
         self.ax = self.canvas.figure.add_subplot(111, projection="3d")
         self._configure_axes_appearance(self.ax)
         self.ax.view_init(elev=20, azim=-60)
+        # Store the original axes bounds so they can be restored after
+        # Matplotlib colorbar calls temporarily shrink the plotting area.
+        self._ax_initial_bounds = tuple(self.ax.get_position().bounds)
 
         controls = QHBoxLayout()
         layout.addLayout(controls)
@@ -4027,6 +4030,8 @@ class Volume3DDialog(QDialog):
         self.thresh_label.setText(f"{thr:.2f}")
 
         self.ax.cla()
+        if hasattr(self, "_ax_initial_bounds"):
+            self.ax.set_position(self._ax_initial_bounds)
         if self.axes_checkbox.isChecked():
             self._configure_axes_appearance(self.ax)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "psutil==7.0.0",
     "matplotlib==3.10.3",
     "joblib==1.4.2",
+    "scikit-image==0.24.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- store the initial 3-D axes bounds when the volume viewer dialog is created
- restore the axes bounds before each redraw so repeated colorbar creation no longer shrinks the plot
- declare scikit-image as a required dependency to support the mesh rendering mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd7267b7a08326b89d8499c9298208