### PR TITLE
Use PyQtGraph for fast 3-D viewers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "matplotlib==3.10.3",
     "joblib==1.4.2",
     "scikit-image==0.24.0",
+    "pyqtgraph==0.13.7",
+    "PyOpenGL==3.1.7",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- replace the 3-D volume viewer with a PyQtGraph OpenGL scene that reuses cached voxel subsets for fast interaction and keeps the colour bar in a lightweight matplotlib canvas
- render GIFTI/FreeSurfer surfaces through PyQtGraph meshes so the geometry is uploaded once and colours can change without recomputing the mesh
- declare new runtime dependencies on pyqtgraph and PyOpenGL to make the accelerated viewers available out of the box

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d10c9984488326820e080a42a1a867