### PR TITLE
Refine 3D viewers and add dedicated FreeSurfer surface dialog

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -205,6 +205,39 @@ def _create_directional_light_shader():
     )
 
 
+def _create_flat_color_shader():
+    """Return an unlit shader for meshes when lighting is disabled."""
+
+    if not HAS_PYQTGRAPH or gl is None:
+        return None
+
+    shader_mod = getattr(gl, "shaders", None)
+    if shader_mod is None:
+        return None
+
+    try:
+        vertex = shader_mod.VertexShader(
+            """
+            void main() {
+                gl_FrontColor = gl_Color;
+                gl_BackColor = gl_Color;
+                gl_Position = ftransform();
+            }
+            """
+        )
+        fragment = shader_mod.FragmentShader(
+            """
+            void main() {
+                gl_FragColor = gl_Color;
+            }
+            """
+        )
+    except Exception:  # pragma: no cover - shader compilation errors occur at runtime
+        return None
+
+    return shader_mod.ShaderProgram(None, [vertex, fragment], uniforms={})
+
+
 _SLICE_ORIENTATIONS = (
     ("sagittal", 0, "Left", "Right"),
     ("coronal", 1, "Posterior", "Anterior"),
@@ -3970,6 +4003,8 @@ class Volume3DDialog(QDialog):
         self._current_bounds: Optional[tuple[np.ndarray, np.ndarray]] = None
         self._colormap_cache: dict[tuple[str, float], mcolors.Colormap] = {}
         self._light_shader = _create_directional_light_shader()
+        self._flat_shader = _create_flat_color_shader()
+        self._lighting_enabled = True
 
         self._fg_color = "#f0f0f0" if self._dark_theme else "#202020"
         self._canvas_bg = "#202020" if self._dark_theme else "#ffffff"
@@ -3979,15 +4014,15 @@ class Volume3DDialog(QDialog):
 
         layout = QVBoxLayout(self)
 
-        splitter = QSplitter(Qt.Vertical)
-        splitter.setChildrenCollapsible(False)
-        splitter.setHandleWidth(12)
-        layout.addWidget(splitter)
+        self._splitter = QSplitter(Qt.Vertical)
+        self._splitter.setChildrenCollapsible(False)
+        self._splitter.setHandleWidth(12)
+        layout.addWidget(self._splitter)
 
-        display_container = QWidget()
-        display_layout = QHBoxLayout(display_container)
-        display_layout.setContentsMargins(0, 0, 0, 0)
-        display_layout.setSpacing(8)
+        self._view_container = QWidget()
+        view_layout = QVBoxLayout(self._view_container)
+        view_layout.setContentsMargins(0, 0, 0, 0)
+        view_layout.setSpacing(0)
 
         # ``GLViewWidget`` renders using OpenGL so panning/zooming the scene does
         # not require recomputing the voxel subset on every interaction.
@@ -3997,21 +4032,26 @@ class Volume3DDialog(QDialog):
         self.view.opts["distance"] = 200
         self.view.opts["elevation"] = 20
         self.view.opts["azimuth"] = -60
-        display_layout.addWidget(self.view, stretch=1)
+        view_layout.addWidget(self.view)
 
-        # A dedicated matplotlib canvas is reused for colour bars so we can keep
-        # the interactive OpenGL viewport focused solely on geometry updates.
-        self._colorbar_canvas = FigureCanvas(plt.Figure(figsize=(1.6, 4.2)))
-        self._colorbar_canvas.setFixedWidth(190)
-        self._colorbar_canvas.figure.patch.set_facecolor(self._canvas_bg)
-        display_layout.addWidget(self._colorbar_canvas)
-
-        splitter.addWidget(display_container)
+        self._splitter.addWidget(self._view_container)
 
         settings_container = QWidget()
         settings_layout = QVBoxLayout(settings_container)
         settings_layout.setContentsMargins(6, 6, 6, 6)
         settings_layout.setSpacing(10)
+
+        # Allow users to dock the settings pane to whichever edge feels most
+        # comfortable when working on small screens.
+        placement_layout = QHBoxLayout()
+        placement_layout.setSpacing(6)
+        placement_label = QLabel("Panel placement:")
+        placement_layout.addWidget(placement_label)
+        self.panel_location_combo = QComboBox()
+        self.panel_location_combo.addItems(["Bottom", "Left", "Right"])
+        placement_layout.addWidget(self.panel_location_combo)
+        placement_layout.addStretch()
+        settings_layout.addLayout(placement_layout)
 
         controls_widget = QWidget()
         controls = QHBoxLayout(controls_widget)
@@ -4170,6 +4210,19 @@ class Volume3DDialog(QDialog):
         self.axis_labels_checkbox.setEnabled(False)
         settings_layout.addWidget(options_group)
 
+        # Embed the colour bar alongside the rest of the controls so it folds
+        # away with the settings pane.
+        colorbar_group = QGroupBox("Colour bar")
+        colorbar_layout = QVBoxLayout(colorbar_group)
+        colorbar_layout.setContentsMargins(8, 6, 8, 6)
+        colorbar_layout.setSpacing(4)
+        self._colorbar_canvas = FigureCanvas(plt.Figure(figsize=(2.6, 1.4)))
+        self._colorbar_canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self._colorbar_canvas.setFixedHeight(180)
+        self._colorbar_canvas.figure.patch.set_facecolor(self._canvas_bg)
+        colorbar_layout.addWidget(self._colorbar_canvas)
+        settings_layout.addWidget(colorbar_group)
+
         slice_group = QGroupBox("Slice planes")
         slice_layout = QVBoxLayout(slice_group)
         slice_layout.setContentsMargins(8, 4, 8, 4)
@@ -4221,6 +4274,10 @@ class Volume3DDialog(QDialog):
         self.lighting_group = QGroupBox("Lighting")
         light_layout = QGridLayout(self.lighting_group)
         light_row = 0
+        self.light_enable_checkbox = QCheckBox("Enable lighting")
+        self.light_enable_checkbox.setChecked(True)
+        light_layout.addWidget(self.light_enable_checkbox, light_row, 0, 1, 3)
+        light_row += 1
         light_layout.addWidget(QLabel("Azimuth:"), light_row, 0)
         self.light_azimuth_slider = QSlider(Qt.Horizontal)
         self.light_azimuth_slider.setRange(-180, 180)
@@ -4255,7 +4312,7 @@ class Volume3DDialog(QDialog):
         light_layout.addWidget(self.light_intensity_slider, light_row, 1)
         self.light_intensity_label = QLabel("1.30×")
         light_layout.addWidget(self.light_intensity_label, light_row, 2)
-        if self._light_shader is None:
+        if self._light_shader is None and self._flat_shader is None:
             self.lighting_group.setEnabled(False)
         settings_layout.addWidget(self.lighting_group)
 
@@ -4264,13 +4321,13 @@ class Volume3DDialog(QDialog):
         settings_layout.addWidget(self.status_label)
         settings_layout.addStretch()
 
-        scroll = QScrollArea()
-        scroll.setWidget(settings_container)
-        scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        splitter.addWidget(scroll)
-        splitter.setStretchFactor(0, 4)
-        splitter.setStretchFactor(1, 1)
+        self._panel_scroll = QScrollArea()
+        self._panel_scroll.setWidget(settings_container)
+        self._panel_scroll.setWidgetResizable(True)
+        self._panel_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._splitter.addWidget(self._panel_scroll)
+        self._splitter.setStretchFactor(0, 4)
+        self._splitter.setStretchFactor(1, 1)
 
         default_name = None
         if default_mode and default_mode in self._aggregators:
@@ -4284,6 +4341,7 @@ class Volume3DDialog(QDialog):
         if default_name:
             self.agg_combo.setCurrentText(default_name)
 
+        self.panel_location_combo.currentTextChanged.connect(self._on_panel_location_change)
         self.agg_combo.currentTextChanged.connect(self._on_agg_change)
         self.render_mode_combo.currentTextChanged.connect(self._on_render_mode_change)
         self.opacity_slider.valueChanged.connect(self._on_opacity_change)
@@ -4294,9 +4352,13 @@ class Volume3DDialog(QDialog):
         self.axes_checkbox.toggled.connect(self._on_axes_toggle)
         self.axis_thickness_slider.valueChanged.connect(self._on_axis_thickness_change)
         self.axis_labels_checkbox.toggled.connect(self._on_axis_labels_toggle)
+        self.light_enable_checkbox.toggled.connect(self._on_light_enabled_toggle)
         self.light_azimuth_slider.valueChanged.connect(self._on_light_setting_change)
         self.light_elevation_slider.valueChanged.connect(self._on_light_setting_change)
         self.light_intensity_slider.valueChanged.connect(self._on_light_setting_change)
+
+        self._apply_panel_layout(self.panel_location_combo.currentText())
+        self._update_light_controls_enabled()
 
         # Prime the UI labels without triggering expensive redraws while we are
         # still constructing the dialog.
@@ -4310,6 +4372,77 @@ class Volume3DDialog(QDialog):
         self._update_mode_dependent_controls()
         self._compute_scalar_volume()
         self._update_plot()
+
+    def _apply_panel_layout(self, location: str) -> None:
+        """Reposition the settings pane relative to the 3-D viewport."""
+
+        if not hasattr(self, "_splitter"):
+            return
+
+        normalised = (location or "bottom").strip().lower()
+        if normalised not in {"bottom", "left", "right"}:
+            normalised = "bottom"
+
+        view_first = True
+        if normalised == "bottom":
+            self._splitter.setOrientation(Qt.Vertical)
+            view_first = True
+        else:
+            self._splitter.setOrientation(Qt.Horizontal)
+            view_first = normalised != "left"
+
+        widgets = [self._view_container, self._panel_scroll]
+        if not view_first:
+            widgets.reverse()
+        for index, widget in enumerate(widgets):
+            if self._splitter.indexOf(widget) != index:
+                self._splitter.insertWidget(index, widget)
+
+        if view_first:
+            self._splitter.setStretchFactor(0, 4)
+            self._splitter.setStretchFactor(1, 1)
+        else:
+            self._splitter.setStretchFactor(0, 1)
+            self._splitter.setStretchFactor(1, 4)
+
+    def _on_panel_location_change(self, location: str) -> None:
+        self._apply_panel_layout(location)
+
+    def _update_light_controls_enabled(self) -> None:
+        enabled = bool(self.lighting_group.isEnabled() and self._lighting_enabled)
+        for widget in (
+            self.light_azimuth_slider,
+            self.light_elevation_slider,
+            self.light_intensity_slider,
+        ):
+            widget.setEnabled(enabled)
+        for label in (
+            self.light_azimuth_label,
+            self.light_elevation_label,
+            self.light_intensity_label,
+        ):
+            label.setEnabled(enabled)
+
+    def _apply_mesh_shader(self) -> None:
+        if self._mesh_item is None:
+            return
+        if self._light_shader is not None and self._lighting_enabled:
+            self._mesh_item.setShader(self._light_shader)
+        elif self._flat_shader is not None:
+            self._mesh_item.setShader(self._flat_shader)
+        else:
+            self._mesh_item.setShader("shaded")
+
+    def _on_light_enabled_toggle(self, checked: bool) -> None:
+        self._lighting_enabled = bool(checked)
+        self._update_light_controls_enabled()
+        if self._lighting_enabled:
+            self._update_light_shader()
+        else:
+            self._apply_mesh_shader()
+        if not self._initialising and self._mesh_item is not None:
+            self._mesh_item.update()
+            self.view.update()
 
     def _normalise_voxel_sizes(self, voxel_sizes):
         if not voxel_sizes:
@@ -4786,7 +4919,8 @@ class Volume3DDialog(QDialog):
 
     def _update_light_shader(self) -> None:
         shader = self._light_shader
-        if shader is None:
+        if shader is None or not self._lighting_enabled:
+            self._apply_mesh_shader()
             return
         azimuth = math.radians(self.light_azimuth_slider.value())
         elevation = math.radians(self.light_elevation_slider.value())
@@ -4801,6 +4935,7 @@ class Volume3DDialog(QDialog):
             max(0.0, self.light_intensity_slider.value() / 100.0),
             0.35,
         ]
+        self._apply_mesh_shader()
 
     def _on_light_setting_change(self, _value: int) -> None:
         self._update_light_labels()
@@ -4828,7 +4963,7 @@ class Volume3DDialog(QDialog):
         fig.clf()
         # ``ScalarMappable`` draws a classic matplotlib colour bar giving users a
         # persistent reference for the current normalisation range.
-        ax = fig.add_axes([0.28, 0.1, 0.58, 0.82])
+        ax = fig.add_axes([0.26, 0.15, 0.48, 0.7])
         norm = plt.Normalize(vmin, vmax)
         mappable = plt.cm.ScalarMappable(norm=norm, cmap=cmap)
         fig.colorbar(mappable, cax=ax)
@@ -5097,12 +5232,15 @@ class Volume3DDialog(QDialog):
         total_voxels = self._estimate_voxels_above_threshold(thr)
         spin = getattr(self, "downsample_spin", None)
         downsample_source = "manual" if spin and spin.value() > 0 else "auto"
+        lighting_suffix = ""
+        if self._light_shader is not None or self._flat_shader is not None:
+            lighting_suffix = " Lighting " + ("enabled." if self._lighting_enabled else "disabled.")
         self.status_label.setText(
             "Point cloud: "
             f"{coords_mm.shape[0]:,} voxels (threshold {thr:.2f}, opacity {alpha:.2f}, "
             f"point size {self.point_slider.value()}). "
             f"Downsample step {step} ({downsample_source}); "
-            f"≈ total voxels ≥ threshold {total_voxels:,}."
+            f"≈ total voxels ≥ threshold {total_voxels:,}.{lighting_suffix}"
             f"{self._slice_status_suffix()}"
         )
 
@@ -5209,20 +5347,15 @@ class Volume3DDialog(QDialog):
         if self._mesh_item is None:
             # ``GLMeshItem`` retains the uploaded vertex buffers so subsequent
             # slider tweaks only update colours instead of reallocating the mesh.
-            shader = self._light_shader if self._light_shader is not None else "shaded"
             self._mesh_item = gl.GLMeshItem(
                 meshdata=meshdata,
                 smooth=False,
-                shader=shader,
+                shader="shaded",
                 drawEdges=False,
             )
             self.view.addItem(self._mesh_item)
         else:
             self._mesh_item.setMeshData(meshdata=meshdata)
-            if self._light_shader is not None:
-                self._mesh_item.setShader(self._light_shader)
-            else:
-                self._mesh_item.setShader("shaded")
 
         self._update_light_shader()
         self._mesh_item.setGLOptions("translucent" if alpha < 0.999 else "opaque")
@@ -5235,11 +5368,14 @@ class Volume3DDialog(QDialog):
         total_voxels = int(np.count_nonzero(self._normalised_volume >= thr))
         spin = getattr(self, "downsample_spin", None)
         downsample_source = "manual" if spin and spin.value() > 0 else "auto"
+        lighting_suffix = ""
+        if self._light_shader is not None or self._flat_shader is not None:
+            lighting_suffix = " Lighting " + ("enabled." if self._lighting_enabled else "disabled.")
         self.status_label.setText(
             "Surface mesh: "
             f"{verts.shape[0]:,} vertices / {faces.shape[0]:,} faces (iso {thr:.2f}, "
             f"opacity {alpha:.2f}). Downsample step {step} ({downsample_source}); "
-            f"marching step {self._surface_step}. Total voxels ≥ level {total_voxels:,}."
+            f"marching step {self._surface_step}. Total voxels ≥ level {total_voxels:,}.{lighting_suffix}"
             f"{self._slice_status_suffix()}"
         )
 
@@ -5258,7 +5394,11 @@ class Volume3DDialog(QDialog):
         self.surface_step_label.setEnabled(is_surface)
         self.surface_step_spin.setEnabled(is_surface)
         if hasattr(self, "lighting_group"):
-            self.lighting_group.setEnabled(is_surface and self._light_shader is not None)
+            self.lighting_group.setEnabled(
+                is_surface
+                and (self._light_shader is not None or self._flat_shader is not None)
+            )
+            self._update_light_controls_enabled()
         if is_surface:
             self.thresh_text.setText("Iso level:")
             self.thresh_slider.setToolTip(
@@ -5349,6 +5489,8 @@ class Surface3DDialog(QDialog):
         self._current_bounds: Optional[tuple[np.ndarray, np.ndarray]] = None
         self._colormap_cache: dict[tuple[str, float], mcolors.Colormap] = {}
         self._light_shader = _create_directional_light_shader()
+        self._flat_shader = _create_flat_color_shader()
+        self._lighting_enabled = True
 
         if self._vertices.size:
             mins = np.min(self._vertices, axis=0).astype(np.float32, copy=False)
@@ -5357,15 +5499,15 @@ class Surface3DDialog(QDialog):
 
         layout = QVBoxLayout(self)
 
-        splitter = QSplitter(Qt.Vertical)
-        splitter.setChildrenCollapsible(False)
-        splitter.setHandleWidth(12)
-        layout.addWidget(splitter)
+        self._splitter = QSplitter(Qt.Vertical)
+        self._splitter.setChildrenCollapsible(False)
+        self._splitter.setHandleWidth(12)
+        layout.addWidget(self._splitter)
 
-        display_container = QWidget()
-        display_layout = QHBoxLayout(display_container)
-        display_layout.setContentsMargins(0, 0, 0, 0)
-        display_layout.setSpacing(8)
+        self._view_container = QWidget()
+        view_layout = QVBoxLayout(self._view_container)
+        view_layout.setContentsMargins(0, 0, 0, 0)
+        view_layout.setSpacing(0)
 
         # ``GLViewWidget`` renders using OpenGL so panning/zooming the scene does
         # not require recomputing the mesh when interacting with the viewport.
@@ -5375,21 +5517,25 @@ class Surface3DDialog(QDialog):
         self.view.opts["distance"] = 200
         self.view.opts["elevation"] = 20
         self.view.opts["azimuth"] = -60
-        display_layout.addWidget(self.view, stretch=1)
+        view_layout.addWidget(self.view)
 
-        # A dedicated matplotlib canvas is reused for colour bars so we can keep
-        # the interactive OpenGL viewport focused solely on geometry updates.
-        self._colorbar_canvas = FigureCanvas(plt.Figure(figsize=(1.6, 4.2)))
-        self._colorbar_canvas.setFixedWidth(190)
-        self._colorbar_canvas.figure.patch.set_facecolor(self._canvas_bg)
-        display_layout.addWidget(self._colorbar_canvas)
-
-        splitter.addWidget(display_container)
+        self._splitter.addWidget(self._view_container)
 
         settings_container = QWidget()
         settings_layout = QVBoxLayout(settings_container)
         settings_layout.setContentsMargins(6, 6, 6, 6)
         settings_layout.setSpacing(10)
+
+        # Allow the combined colour bar + control pane to be docked on the
+        # side or bottom of the viewport.
+        placement_layout = QHBoxLayout()
+        placement_layout.setSpacing(6)
+        placement_layout.addWidget(QLabel("Panel placement:"))
+        self.panel_location_combo = QComboBox()
+        self.panel_location_combo.addItems(["Bottom", "Left", "Right"])
+        placement_layout.addWidget(self.panel_location_combo)
+        placement_layout.addStretch()
+        settings_layout.addLayout(placement_layout)
 
         scalar_row = QHBoxLayout()
         scalar_row.setContentsMargins(0, 0, 0, 0)
@@ -5455,6 +5601,19 @@ class Surface3DDialog(QDialog):
         self.color_intensity_label = QLabel("1.00×")
         appearance_layout.addWidget(self.color_intensity_label, row, 2)
         settings_layout.addWidget(appearance_group)
+
+        # Keep the colour bar within the scroll area so it collapses together
+        # with the rest of the surface controls.
+        colorbar_group = QGroupBox("Colour bar")
+        colorbar_layout = QVBoxLayout(colorbar_group)
+        colorbar_layout.setContentsMargins(8, 6, 8, 6)
+        colorbar_layout.setSpacing(4)
+        self._colorbar_canvas = FigureCanvas(plt.Figure(figsize=(2.6, 1.4)))
+        self._colorbar_canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self._colorbar_canvas.setFixedHeight(180)
+        self._colorbar_canvas.figure.patch.set_facecolor(self._canvas_bg)
+        colorbar_layout.addWidget(self._colorbar_canvas)
+        settings_layout.addWidget(colorbar_group)
 
         axes_group = QGroupBox("Axes")
         axes_layout = QGridLayout(axes_group)
@@ -5540,6 +5699,10 @@ class Surface3DDialog(QDialog):
         self.lighting_group = QGroupBox("Lighting")
         light_layout = QGridLayout(self.lighting_group)
         light_row = 0
+        self.light_enable_checkbox = QCheckBox("Enable lighting")
+        self.light_enable_checkbox.setChecked(True)
+        light_layout.addWidget(self.light_enable_checkbox, light_row, 0, 1, 3)
+        light_row += 1
         light_layout.addWidget(QLabel("Azimuth:"), light_row, 0)
         self.light_azimuth_slider = QSlider(Qt.Horizontal)
         self.light_azimuth_slider.setRange(-180, 180)
@@ -5574,7 +5737,7 @@ class Surface3DDialog(QDialog):
         light_layout.addWidget(self.light_intensity_slider, light_row, 1)
         self.light_intensity_label = QLabel("1.30×")
         light_layout.addWidget(self.light_intensity_label, light_row, 2)
-        if self._light_shader is None:
+        if self._light_shader is None and self._flat_shader is None:
             self.lighting_group.setEnabled(False)
         settings_layout.addWidget(self.lighting_group)
 
@@ -5583,14 +5746,15 @@ class Surface3DDialog(QDialog):
         settings_layout.addWidget(self.status_label)
         settings_layout.addStretch()
 
-        scroll = QScrollArea()
-        scroll.setWidget(settings_container)
-        scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
-        splitter.addWidget(scroll)
-        splitter.setStretchFactor(0, 4)
-        splitter.setStretchFactor(1, 1)
+        self._panel_scroll = QScrollArea()
+        self._panel_scroll.setWidget(settings_container)
+        self._panel_scroll.setWidgetResizable(True)
+        self._panel_scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self._splitter.addWidget(self._panel_scroll)
+        self._splitter.setStretchFactor(0, 4)
+        self._splitter.setStretchFactor(1, 1)
 
+        self.panel_location_combo.currentTextChanged.connect(self._on_panel_location_change)
         self.scalar_combo.currentIndexChanged.connect(self._on_scalar_change)
         self.colormap_combo.currentTextChanged.connect(self._on_colormap_change)
         self.opacity_slider.valueChanged.connect(self._on_opacity_change)
@@ -5598,9 +5762,13 @@ class Surface3DDialog(QDialog):
         self.axes_checkbox.toggled.connect(self._on_axes_toggle)
         self.axis_thickness_slider.valueChanged.connect(self._on_axis_thickness_change)
         self.axis_labels_checkbox.toggled.connect(self._on_axis_labels_toggle)
+        self.light_enable_checkbox.toggled.connect(self._on_light_enabled_toggle)
         self.light_azimuth_slider.valueChanged.connect(self._on_light_setting_change)
         self.light_elevation_slider.valueChanged.connect(self._on_light_setting_change)
         self.light_intensity_slider.valueChanged.connect(self._on_light_setting_change)
+
+        self._apply_panel_layout(self.panel_location_combo.currentText())
+        self._update_light_controls_enabled()
 
         # Prepare labels and shader uniforms before the first draw call.
         self._on_axis_thickness_change(self.axis_thickness_slider.value())
@@ -5611,6 +5779,77 @@ class Surface3DDialog(QDialog):
 
         self._initialising = False
         self._update_plot()
+
+    def _apply_panel_layout(self, location: str) -> None:
+        """Reorder the settings splitter when users move the control pane."""
+
+        if not hasattr(self, "_splitter"):
+            return
+
+        normalised = (location or "bottom").strip().lower()
+        if normalised not in {"bottom", "left", "right"}:
+            normalised = "bottom"
+
+        view_first = True
+        if normalised == "bottom":
+            self._splitter.setOrientation(Qt.Vertical)
+            view_first = True
+        else:
+            self._splitter.setOrientation(Qt.Horizontal)
+            view_first = normalised != "left"
+
+        widgets = [self._view_container, self._panel_scroll]
+        if not view_first:
+            widgets.reverse()
+        for index, widget in enumerate(widgets):
+            if self._splitter.indexOf(widget) != index:
+                self._splitter.insertWidget(index, widget)
+
+        if view_first:
+            self._splitter.setStretchFactor(0, 4)
+            self._splitter.setStretchFactor(1, 1)
+        else:
+            self._splitter.setStretchFactor(0, 1)
+            self._splitter.setStretchFactor(1, 4)
+
+    def _on_panel_location_change(self, location: str) -> None:
+        self._apply_panel_layout(location)
+
+    def _update_light_controls_enabled(self) -> None:
+        enabled = bool(self.lighting_group.isEnabled() and self._lighting_enabled)
+        for widget in (
+            self.light_azimuth_slider,
+            self.light_elevation_slider,
+            self.light_intensity_slider,
+        ):
+            widget.setEnabled(enabled)
+        for label in (
+            self.light_azimuth_label,
+            self.light_elevation_label,
+            self.light_intensity_label,
+        ):
+            label.setEnabled(enabled)
+
+    def _apply_mesh_shader(self) -> None:
+        if self._mesh_item is None:
+            return
+        if self._light_shader is not None and self._lighting_enabled:
+            self._mesh_item.setShader(self._light_shader)
+        elif self._flat_shader is not None:
+            self._mesh_item.setShader(self._flat_shader)
+        else:
+            self._mesh_item.setShader("shaded")
+
+    def _on_light_enabled_toggle(self, checked: bool) -> None:
+        self._lighting_enabled = bool(checked)
+        self._update_light_controls_enabled()
+        if self._lighting_enabled:
+            self._update_light_shader()
+        else:
+            self._apply_mesh_shader()
+        if not self._initialising and self._mesh_item is not None:
+            self._mesh_item.update()
+            self.view.update()
 
     def _current_color_intensity(self) -> float:
         return max(0.1, self.color_intensity_slider.value() / 100.0)
@@ -5836,7 +6075,8 @@ class Surface3DDialog(QDialog):
 
     def _update_light_shader(self) -> None:
         shader = self._light_shader
-        if shader is None:
+        if shader is None or not self._lighting_enabled:
+            self._apply_mesh_shader()
             return
         azimuth = math.radians(self.light_azimuth_slider.value())
         elevation = math.radians(self.light_elevation_slider.value())
@@ -5851,6 +6091,7 @@ class Surface3DDialog(QDialog):
             max(0.0, self.light_intensity_slider.value() / 100.0),
             0.35,
         ]
+        self._apply_mesh_shader()
 
     def _on_light_setting_change(self, _value: int) -> None:
         self._update_light_labels()
@@ -5954,20 +6195,15 @@ class Surface3DDialog(QDialog):
             summary += "Constant colouring applied. "
 
         if self._mesh_item is None:
-            shader = self._light_shader if self._light_shader is not None else "shaded"
             self._mesh_item = gl.GLMeshItem(
                 meshdata=meshdata,
                 smooth=False,
-                shader=shader,
+                shader="shaded",
                 drawEdges=False,
             )
             self.view.addItem(self._mesh_item)
         else:
             self._mesh_item.setMeshData(meshdata=meshdata)
-            if self._light_shader is not None:
-                self._mesh_item.setShader(self._light_shader)
-            else:
-                self._mesh_item.setShader("shaded")
         self._update_light_shader()
         self._mesh_item.setGLOptions("translucent" if alpha < 0.999 else "opaque")
 
@@ -5976,10 +6212,263 @@ class Surface3DDialog(QDialog):
         self._update_scene_bounds(mins, maxs)
 
         summary += f"Opacity {alpha:.2f}."
+        if self._light_shader is not None or self._flat_shader is not None:
+            summary += " Lighting " + ("enabled." if self._lighting_enabled else "disabled.")
         if self._scalar_fields and (not scalar_key or scalar_key not in self._scalar_fields):
             summary += " Select a scalar field to colour the surface."
         summary += self._slice_status_suffix()
         self.status_label.setText(summary)
+
+
+class FreeSurferSurfaceDialog(QDialog):
+    """Simplified viewer tailored for FreeSurfer ``*.pial``/``*.white`` meshes."""
+
+    def __init__(
+        self,
+        parent,
+        vertices: np.ndarray,
+        faces: np.ndarray,
+        title: Optional[str] = None,
+        dark_theme: bool = False,
+    ) -> None:
+        super().__init__(parent)
+        if not HAS_PYQTGRAPH:
+            raise RuntimeError(
+                "Surface rendering requires the optional 'pyqtgraph' dependency."
+            )
+
+        self.setWindowTitle(title or "FreeSurfer Surface")
+        self.resize(900, 720)
+        self.setMinimumSize(620, 480)
+        self.setSizeGripEnabled(True)
+
+        verts = np.asarray(vertices, dtype=np.float32)
+        faces_arr = np.asarray(faces, dtype=np.int32)
+        if verts.ndim != 2 or verts.shape[1] != 3:
+            raise ValueError("Surface vertices must be an (N, 3) array")
+        if faces_arr.ndim != 2 or faces_arr.shape[1] != 3:
+            raise ValueError("Surface faces must be an (M, 3) array")
+        if faces_arr.size and int(faces_arr.max(initial=-1)) >= verts.shape[0]:
+            raise ValueError("Face indices exceed available vertices")
+
+        self._vertices = verts
+        self._faces = faces_arr
+        self._fg_color = "#f0f0f0" if dark_theme else "#202020"
+        self._canvas_bg = "#202020" if dark_theme else "#ffffff"
+
+        self._mesh_item: Optional[gl.GLMeshItem] = None
+        self._axis_item: Optional[gl.GLAxisItem] = None
+        self._current_bounds: Optional[tuple[np.ndarray, np.ndarray]] = None
+        self._light_shader = _create_directional_light_shader()
+        self._flat_shader = _create_flat_color_shader()
+        self._lighting_enabled = self._light_shader is not None
+
+        layout = QVBoxLayout(self)
+
+        self.view = gl.GLViewWidget()
+        self.view.setBackgroundColor(self._canvas_bg)
+        self.view.opts["distance"] = 200
+        self.view.opts["elevation"] = 20
+        self.view.opts["azimuth"] = -60
+        layout.addWidget(self.view, 1)
+
+        controls = QGroupBox("Display settings")
+        controls_layout = QGridLayout(controls)
+        controls_layout.setColumnStretch(1, 1)
+
+        # Provide a handful of constant colours so users can quickly switch the
+        # appearance without diving into advanced scalar options.
+        self._colour_presets: list[tuple[str, str]] = [
+            ("Clay", "#d87c5a"),
+            ("Slate", "#4f6d7a"),
+            ("Bone", "#e9d8a6"),
+            ("Forest", "#2a9d8f"),
+            ("Carbon", "#5c5f66"),
+        ]
+
+        row = 0
+        controls_layout.addWidget(QLabel("Surface colour:"), row, 0)
+        self.color_combo = QComboBox()
+        for name, colour in self._colour_presets:
+            self.color_combo.addItem(name, userData=colour)
+        controls_layout.addWidget(self.color_combo, row, 1, 1, 2)
+
+        row += 1
+        controls_layout.addWidget(QLabel("Opacity:"), row, 0)
+        self.opacity_slider = QSlider(Qt.Horizontal)
+        self.opacity_slider.setRange(10, 100)
+        self.opacity_slider.setValue(85)
+        controls_layout.addWidget(self.opacity_slider, row, 1)
+        self.opacity_label = QLabel("0.85")
+        controls_layout.addWidget(self.opacity_label, row, 2)
+
+        row += 1
+        self.axes_checkbox = QCheckBox("Show axes")
+        controls_layout.addWidget(self.axes_checkbox, row, 0, 1, 3)
+
+        row += 1
+        self.light_checkbox = QCheckBox("Enable lighting")
+        self.light_checkbox.setChecked(self._lighting_enabled)
+        controls_layout.addWidget(self.light_checkbox, row, 0, 1, 3)
+        if self._light_shader is None and self._flat_shader is None:
+            self._lighting_enabled = False
+            self.light_checkbox.setEnabled(False)
+            self.light_checkbox.setChecked(False)
+
+        layout.addWidget(controls)
+
+        self.status_label = QLabel("")
+        self.status_label.setWordWrap(True)
+        layout.addWidget(self.status_label)
+
+        self._initialising = True
+
+        self.color_combo.currentIndexChanged.connect(self._on_color_change)
+        self.opacity_slider.valueChanged.connect(self._on_opacity_change)
+        self.axes_checkbox.toggled.connect(self._on_axes_toggle)
+        self.light_checkbox.toggled.connect(self._on_light_toggle)
+
+        if self._vertices.size:
+            mins = np.min(self._vertices, axis=0).astype(np.float32, copy=False)
+            maxs = np.max(self._vertices, axis=0).astype(np.float32, copy=False)
+        else:
+            mins = np.zeros(3, dtype=np.float32)
+            maxs = np.zeros(3, dtype=np.float32)
+        self._update_scene_bounds(mins, maxs)
+        self._update_axis_item()
+        self._update_light_shader()
+        self._update_mesh()
+
+        self._initialising = False
+        self._update_status()
+
+    def _current_colour_rgba(self) -> np.ndarray:
+        colour_hex = self.color_combo.currentData()
+        if not colour_hex:
+            colour_hex = "#d87c5a"
+        rgb = np.array(mcolors.to_rgb(str(colour_hex)), dtype=np.float32)
+        alpha = np.clip(self.opacity_slider.value() / 100.0, 0.1, 1.0)
+        colours = np.empty((self._vertices.shape[0], 4), dtype=np.float32)
+        colours[:, :3] = rgb
+        colours[:, 3] = alpha
+        return colours
+
+    def _update_mesh(self) -> None:
+        if self._vertices.size == 0 or self._faces.size == 0:
+            if self._mesh_item is not None:
+                self.view.removeItem(self._mesh_item)
+                self._mesh_item = None
+            self.status_label.setText("Surface mesh has no vertices or faces to render.")
+            return
+
+        meshdata = gl.MeshData(vertexes=self._vertices, faces=self._faces)
+        colours = self._current_colour_rgba()
+        meshdata.setVertexColors(colours)
+
+        if self._mesh_item is None:
+            self._mesh_item = gl.GLMeshItem(
+                meshdata=meshdata,
+                smooth=False,
+                shader="shaded",
+                drawEdges=False,
+            )
+            self.view.addItem(self._mesh_item)
+        else:
+            self._mesh_item.setMeshData(meshdata=meshdata)
+
+        self._apply_mesh_shader()
+        alpha = self.opacity_slider.value() / 100.0
+        self._mesh_item.setGLOptions("translucent" if alpha < 0.999 else "opaque")
+        if not self._initialising:
+            self.view.update()
+
+    def _update_status(self) -> None:
+        if self._vertices.size == 0 or self._faces.size == 0:
+            summary = "Surface mesh has no vertices or faces to render."
+        else:
+            mins, maxs = self._current_bounds if self._current_bounds else (
+                np.zeros(3, dtype=np.float32),
+                np.zeros(3, dtype=np.float32),
+            )
+            summary = (
+                f"Surface mesh: {self._vertices.shape[0]:,} vertices / "
+                f"{self._faces.shape[0]:,} faces. Opacity {self.opacity_slider.value() / 100.0:.2f}. "
+                f"Colour preset: {self.color_combo.currentText()}. "
+                f"Bounds X {mins[0]:.1f}–{maxs[0]:.1f} mm, "
+                f"Y {mins[1]:.1f}–{maxs[1]:.1f} mm, Z {mins[2]:.1f}–{maxs[2]:.1f} mm. "
+            )
+        if self._light_shader is None and self._flat_shader is None:
+            summary += " Lighting controls unavailable."
+        else:
+            summary += " Lighting " + ("enabled." if self._lighting_enabled else "disabled.")
+        self.status_label.setText(summary)
+
+    def _apply_mesh_shader(self) -> None:
+        if self._mesh_item is None:
+            return
+        if self._light_shader is not None and self._lighting_enabled:
+            self._mesh_item.setShader(self._light_shader)
+        elif self._flat_shader is not None:
+            self._mesh_item.setShader(self._flat_shader)
+        else:
+            self._mesh_item.setShader("shaded")
+
+    def _update_light_shader(self) -> None:
+        if self._light_shader is None:
+            return
+        self._light_shader["lightDir"] = [0.5, 0.3, 0.8]
+        self._light_shader["lightParams"] = [1.0, 0.35]
+        self._apply_mesh_shader()
+
+    def _update_scene_bounds(self, mins: np.ndarray, maxs: np.ndarray) -> None:
+        spans = np.maximum(maxs - mins, 1e-3)
+        center = (mins + maxs) / 2.0
+        self._current_bounds = (mins, maxs)
+        self.view.opts["center"] = pg.Vector(center[0], center[1], center[2])
+        self.view.opts["distance"] = float(np.linalg.norm(spans) * 1.2)
+
+    def _update_axis_item(self) -> None:
+        if not self.axes_checkbox.isChecked():
+            if self._axis_item is not None:
+                self.view.removeItem(self._axis_item)
+                self._axis_item = None
+            return
+        if self._axis_item is None:
+            axis = _AdjustableAxisItem() if '_AdjustableAxisItem' in globals() else gl.GLAxisItem()
+            axis.setSize(1, 1, 1)
+            self.view.addItem(axis)
+            self._axis_item = axis
+        mins, maxs = self._current_bounds if self._current_bounds else (
+            np.zeros(3, dtype=np.float32),
+            np.ones(3, dtype=np.float32),
+        )
+        spans = np.maximum(maxs - mins, 1e-3)
+        self._axis_item.setSize(spans[0], spans[1], spans[2])
+        if hasattr(self._axis_item, "setLineWidth"):
+            self._axis_item.setLineWidth(2.0)
+
+    def _on_color_change(self, _index: int) -> None:
+        self._update_mesh()
+        if not self._initialising:
+            self._update_status()
+
+    def _on_opacity_change(self, value: int) -> None:
+        self.opacity_label.setText(f"{value / 100.0:.2f}")
+        self._update_mesh()
+        if not self._initialising:
+            self._update_status()
+
+    def _on_axes_toggle(self, _checked: bool) -> None:
+        self._update_axis_item()
+        if not self._initialising:
+            self.view.update()
+
+    def _on_light_toggle(self, checked: bool) -> None:
+        self._lighting_enabled = bool(checked)
+        self._apply_mesh_shader()
+        if not self._initialising and self._mesh_item is not None:
+            self._mesh_item.update()
+        self._update_status()
 
 
 class MetadataViewer(QWidget):
@@ -6598,16 +7087,27 @@ class MetadataViewer(QWidget):
             else "Surface Viewer"
         )
 
+        surface_type = str(self.surface_data.get('type') or '').lower()
+
         try:
-            dialog = Surface3DDialog(
-                self,
-                self.surface_data.get('vertices'),
-                self.surface_data.get('faces'),
-                scalars=self.surface_data.get('scalars'),
-                meta=self.surface_data.get('meta'),
-                title=title,
-                dark_theme=self._is_dark_theme(),
-            )
+            if surface_type == 'freesurfer':
+                dialog = FreeSurferSurfaceDialog(
+                    self,
+                    self.surface_data.get('vertices'),
+                    self.surface_data.get('faces'),
+                    title=title,
+                    dark_theme=self._is_dark_theme(),
+                )
+            else:
+                dialog = Surface3DDialog(
+                    self,
+                    self.surface_data.get('vertices'),
+                    self.surface_data.get('faces'),
+                    scalars=self.surface_data.get('scalars'),
+                    meta=self.surface_data.get('meta'),
+                    title=title,
+                    dark_theme=self._is_dark_theme(),
+                )
         except Exception as exc:  # pragma: no cover - interactive error reporting
             logging.exception("Failed to initialise surface viewer")
             QMessageBox.critical(


### PR DESCRIPTION
## Summary
- add a reusable flat-colour shader so the OpenGL lighting can be toggled at runtime
- embed the colour bar within the scrollable control pane, let users dock the pane on any edge, and add explicit lighting toggles in the volume and surface 3-D viewers
- introduce a lightweight FreeSurferSurfaceDialog with constant-colour presets and lighting control, and route FreeSurfer meshes to it from the metadata viewer

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d2bb526fe88326abad48f469f4bf12