### PR TITLE
Guard physio conversion against mismatched DICOMs

### DIFF
--- a/tests/test_run_heudiconv_physio.py
+++ b/tests/test_run_heudiconv_physio.py
@@ -4,11 +4,30 @@ from textwrap import dedent
 from pathlib import Path
 
 import pandas as pd
+from pydicom.dataset import Dataset, FileDataset
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
 
 from bids_manager.run_heudiconv_from_heuristic import (
     convert_physio_series,
     load_heuristic_module,
 )
+
+
+def _write_dicom(path: Path, series_uid: str, description: str) -> None:
+    """Create a minimal DICOM file containing the provided metadata."""
+
+    meta = Dataset()
+    meta.MediaStorageSOPClassUID = generate_uid()
+    meta.MediaStorageSOPInstanceUID = generate_uid()
+    meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds = FileDataset(path.name, {}, file_meta=meta, preamble=b"\0" * 128)
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+    ds.SeriesInstanceUID = series_uid
+    ds.SeriesDescription = description
+    ds.PatientName = "Test^Patient"
+    ds.save_as(path)
 
 
 def _write_simple_heuristic(path: Path) -> None:
@@ -53,7 +72,7 @@ def test_convert_physio_series_invokes_bidsphysio(tmp_path, monkeypatch):
     physio_dir = raw_root / "Subject" / "PHYSIO"
     physio_dir.mkdir(parents=True)
     physio_file = physio_dir / "physio.dcm"
-    physio_file.write_bytes(b"DICM")
+    _write_dicom(physio_file, "123", "PHYSIO")
 
     df = pd.DataFrame(
         [
@@ -88,6 +107,50 @@ def test_convert_physio_series_invokes_bidsphysio(tmp_path, monkeypatch):
     ]
 
 
+def test_convert_physio_series_prefers_matching_uid(tmp_path, monkeypatch):
+    heur_path = tmp_path / "heuristic_physio.py"
+    _write_simple_heuristic(heur_path)
+    module = load_heuristic_module(heur_path)
+
+    raw_root = tmp_path / "raw"
+    bids_out = tmp_path / "bids"
+    physio_dir = raw_root / "Subject" / "PHYSIO"
+    physio_dir.mkdir(parents=True)
+
+    unrelated = physio_dir / "other.dcm"
+    target = physio_dir / "physio.dcm"
+    _write_dicom(unrelated, "999", "OTHER")
+    _write_dicom(target, "123", "PHYSIO")
+
+    df = pd.DataFrame(
+        [
+            {
+                "StudyDescription": "Example Study",
+                "source_folder": "Subject/PHYSIO",
+                "sequence": "PHYSIO",
+                "series_uid": "123",
+                "modality": "physio",
+                "include": 1,
+            }
+        ]
+    )
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_dcm2bids(src: str, prefix: str) -> None:
+        calls.append((src, prefix))
+
+    monkeypatch.setattr(
+        "bids_manager.run_heudiconv_from_heuristic.dcm2bidsphysio.dcm2bids",
+        fake_dcm2bids,
+    )
+
+    convert_physio_series(raw_root, bids_out, module, df)
+
+    assert calls, "Physio conversion should have been invoked"
+    assert calls[0][0] == str(target)
+
+
 def test_convert_physio_series_respects_include_flag(tmp_path, monkeypatch):
     heur_path = tmp_path / "heuristic_physio.py"
     _write_simple_heuristic(heur_path)
@@ -97,7 +160,7 @@ def test_convert_physio_series_respects_include_flag(tmp_path, monkeypatch):
     bids_out = tmp_path / "bids"
     physio_dir = raw_root / "Subject" / "PHYSIO"
     physio_dir.mkdir(parents=True)
-    physio_dir.joinpath("physio.dcm").write_bytes(b"DICM")
+    _write_dicom(physio_dir / "physio.dcm", "123", "PHYSIO")
 
     df = pd.DataFrame(
         [
@@ -120,3 +183,43 @@ def test_convert_physio_series_respects_include_flag(tmp_path, monkeypatch):
     )
 
     convert_physio_series(raw_root, bids_out, module, df)
+
+
+def test_convert_physio_series_skips_when_uid_missing(tmp_path, monkeypatch):
+    heur_path = tmp_path / "heuristic_physio.py"
+    _write_simple_heuristic(heur_path)
+    module = load_heuristic_module(heur_path)
+
+    raw_root = tmp_path / "raw"
+    bids_out = tmp_path / "bids"
+    physio_dir = raw_root / "Subject" / "PHYSIO"
+    physio_dir.mkdir(parents=True)
+    _write_dicom(physio_dir / "first.dcm", "111", "OTHER")
+    _write_dicom(physio_dir / "second.dcm", "222", "OTHER")
+
+    df = pd.DataFrame(
+        [
+            {
+                "StudyDescription": "Example Study",
+                "source_folder": "Subject/PHYSIO",
+                "sequence": "PHYSIO",
+                "series_uid": "999",
+                "modality": "physio",
+                "include": 1,
+            }
+        ]
+    )
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_dcm2bids(src: str, prefix: str) -> None:
+        calls.append((src, prefix))
+
+    monkeypatch.setattr(
+        "bids_manager.run_heudiconv_from_heuristic.dcm2bidsphysio.dcm2bids",
+        fake_dcm2bids,
+    )
+
+    convert_physio_series(raw_root, bids_out, module, df)
+
+    assert calls == []


### PR DESCRIPTION
## Summary
- validate candidate physio DICOM files by checking their SeriesInstanceUID and metadata before invoking bidsphysio
- drop the generic fallback that picked arbitrary files when no match was found
- extend the physio conversion tests to cover the skip path when no matching UID exists

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d546b517ec8326a62e692065f5c828