### PR TITLE
Normalize duplicate study names across utilities

### DIFF
--- a/bids_manager/_study_utils.py
+++ b/bids_manager/_study_utils.py
@@ -1,0 +1,94 @@
+"""Utility helpers for handling study names.
+
+This module centralizes small helpers that operate on study names so the
+behavior is consistent across the different entry points.  The helpers are
+tiny, but placing them in their own module makes it easy to share the logic
+between the GUI, command line utilities, and background data preparation
+without creating import cycles.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Regular expression that captures alphanumeric "words" inside a study name.
+# The logic in :func:`normalize_study_name` walks through these matches and keeps
+# track of consecutive duplicates.
+_WORD_RE = re.compile(r"[0-9A-Za-z]+")
+
+
+def normalize_study_name(raw: str) -> str:
+    """Return ``raw`` with consecutive duplicate words removed.
+
+    Study descriptions exported from PACS or spreadsheets occasionally contain
+    repeated words (for example ``"study_study"`` or ``"BIDS BIDS"``).  These
+    repetitions often come from manual copy/paste errors and later cause issues
+    when the name is used as a folder on disk.  The function below removes such
+    repeats **case-insensitively** while leaving the surrounding punctuation and
+    spacing untouched so the resulting string still reads naturally for the
+    user.
+
+    Parameters
+    ----------
+    raw:
+        Original study name as exported from metadata.  Non-string values are
+        coerced to strings so the helper can safely operate on values from
+        :mod:`pandas` data frames.
+
+    Returns
+    -------
+    str
+        The cleaned study name where direct repetitions of the same alphanumeric
+        token have been collapsed into a single occurrence.  If *raw* contains
+        no words the input is returned unchanged.
+    """
+
+    text = "" if raw is None else str(raw)
+    text = text.strip()
+    if not text:
+        return ""
+
+    pieces: list[str] = []
+    last_word: str | None = None
+    cursor = 0
+
+    for match in _WORD_RE.finditer(text):
+        start, end = match.span()
+
+        # Preserve whatever characters appear between the previous word and the
+        # current one (underscores, dashes, spaces, …) so the user sees the
+        # exact same separators in the cleaned value.
+        if start > cursor:
+            separator = text[cursor:start]
+            if separator:
+                pieces.append(separator)
+
+        word = match.group(0)
+        lowered = word.lower()
+
+        if lowered != last_word:
+            # This word is different from the previous one (ignoring case), so
+            # keep it and update our tracking state.
+            pieces.append(word)
+            last_word = lowered
+        else:
+            # When we detect a duplicate we also remove the separator that was
+            # appended just above, preventing leftover characters such as
+            # trailing underscores when turning ``"study_study"`` into
+            # ``"study"``.
+            if start > cursor and pieces:
+                separator = text[cursor:start]
+                if pieces[-1] == separator:
+                    pieces.pop()
+
+        cursor = end
+
+    # Include any trailing punctuation that came after the final word.
+    if cursor < len(text):
+        pieces.append(text[cursor:])
+
+    return "".join(pieces).strip()
+
+
+__all__ = ["normalize_study_name"]
+

--- a/bids_manager/build_heuristic_from_tsv.py
+++ b/bids_manager/build_heuristic_from_tsv.py
@@ -24,6 +24,7 @@ try:
         build_preview_names,
     )
     from .schema_config import DEFAULT_SCHEMA_DIR
+    from ._study_utils import normalize_study_name
 except Exception:
     # Fallback for direct script execution from a checkout. When the module is
     # invoked via ``python build_heuristic_from_tsv.py`` the parent package is
@@ -34,6 +35,7 @@ except Exception:
         build_preview_names,
     )
     from schema_config import DEFAULT_SCHEMA_DIR  # type: ignore
+    from _study_utils import normalize_study_name  # type: ignore
 
 # -----------------------------------------------------------------------------
 # Configuration
@@ -444,6 +446,11 @@ def generate(tsv: Path, out_dir: Path, only_last_repeated: bool = False) -> None
     """
 
     df = pd.read_csv(tsv, sep="\t", keep_default_na=False)
+
+    if "StudyDescription" in df.columns:
+        # Collapse duplicate tokens (``study_study`` → ``study``) before grouping
+        # by study so each heuristic is generated only once per logical study.
+        df["StudyDescription"] = df["StudyDescription"].apply(normalize_study_name)
 
     # Drop rows with unwanted modalities
     mask = df.modality.isin(SKIP_BY_DEFAULT)

--- a/bids_manager/dicom_inventory.py
+++ b/bids_manager/dicom_inventory.py
@@ -45,6 +45,8 @@ import pandas as pd
 import pydicom
 from pydicom.multival import MultiValue
 
+from ._study_utils import normalize_study_name
+
 # Preview name helpers – loaded lazily so ``scan_dicoms_long`` can store
 # proposed BIDS names directly in the TSV.  We guard the import to keep the
 # inventory script functional even if the renamer dependencies are missing.
@@ -319,7 +321,8 @@ def scan_dicoms_long(
             or getattr(ds, "StudyName", None)
             or "n/a"
         )
-        study = str(study).strip()
+        # Normalize to remove repeated words (``study_study`` → ``study``).
+        study = normalize_study_name(study)
         subj_key = f"{subj}||{study}"
         rel = os.path.relpath(root, root_dir)
         folder = root_dir.name if rel == "." else rel

--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -107,6 +107,7 @@ from .schema_renamer import (
     build_preview_names,
     apply_post_conversion_rename,
 )
+from ._study_utils import normalize_study_name
 try:
     import psutil
     HAS_PSUTIL = True
@@ -460,8 +461,10 @@ def _dedup_parts(*parts: str) -> str:
 
 
 def _safe_stem(text: str) -> str:
-    """Return filename-friendly version of ``text``."""
-    return re.sub(r"[^0-9A-Za-z_-]+", "_", text.strip()).strip("_")
+    """Return filename-friendly version of ``text`` used for study folders."""
+
+    cleaned = normalize_study_name(text)
+    return re.sub(r"[^0-9A-Za-z_-]+", "_", cleaned).strip("_")
 
 
 def _format_subject_id(num: int) -> str:
@@ -2123,7 +2126,8 @@ class BIDSManager(QMainWindow):
             src_item.setFlags(src_item.flags() & ~Qt.ItemIsEditable)
             self.mapping_table.setItem(r, 1, src_item)
 
-            study = _clean(row.get('StudyDescription'))
+            study_raw = _clean(row.get('StudyDescription'))
+            study = normalize_study_name(study_raw)
 
             study_item = QTableWidgetItem(study)
             study_item.setFlags(study_item.flags() & ~Qt.ItemIsEditable)

--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -20,6 +20,8 @@ from bidsphysio import dcm2bidsphysio
 from pydicom import dcmread
 from pydicom.dataset import Dataset
 
+from ._study_utils import normalize_study_name
+
 # Acceptable DICOM file extensions (lower case)
 # Some Siemens datasets omit file extensions; we therefore supplement the
 # extension check with a quick sniff of the header for the ``DICM`` tag.
@@ -302,8 +304,15 @@ def clean_name(raw: str) -> str:
     return "".join(ch for ch in raw if ch.isalnum())
 
 def safe_stem(text: str) -> str:
-    """Return filename-friendly version of *text* (used for study names)."""
-    return re.sub(r"[^0-9A-Za-z_-]+", "_", text.strip()).strip("_")
+    """Return filename-friendly version of *text* (used for study names).
+
+    Study identifiers are cleaned with :func:`normalize_study_name` first so we
+    collapse accidental repeats such as ``"study_study"`` into a single token
+    before substituting filesystem-friendly underscores.
+    """
+
+    cleaned = normalize_study_name(text)
+    return re.sub(r"[^0-9A-Za-z_-]+", "_", cleaned).strip("_")
 
 
 def physical_by_clean(raw_root: Path) -> Dict[str, str]:


### PR DESCRIPTION
## Summary
- add a shared helper to collapse repeated words in study names
- apply the normalization when scanning DICOMs and generating heuristics
- ensure GUI and command-line safe_stem logic produces deduplicated study folders

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da8c7194888326aa0c3063e7a28d23