### PR TITLE
Fix run_heudiconv import for standalone execution

### DIFF
--- a/bids_manager/run_heudiconv_from_heuristic.py
+++ b/bids_manager/run_heudiconv_from_heuristic.py
@@ -20,7 +20,7 @@ from bidsphysio import dcm2bidsphysio
 from pydicom import dcmread
 from pydicom.dataset import Dataset
 
-from ._study_utils import normalize_study_name
+from bids_manager._study_utils import normalize_study_name
 
 # Acceptable DICOM file extensions (lower case)
 # Some Siemens datasets omit file extensions; we therefore supplement the


### PR DESCRIPTION
## Summary
- update run_heudiconv_from_heuristic to import normalize_study_name via the package namespace so the module can be executed directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db9abe7c8883269311b025ab5bcce5