### PR TITLE
Fix fieldmap suffix normalization for schema proposals

### DIFF
--- a/bids_manager/renaming/schema_renamer.py
+++ b/bids_manager/renaming/schema_renamer.py
@@ -367,42 +367,87 @@ class SeriesInfo:
     extra: Dict[str, str]
 
 
-def _normalize_suffix(modality: str) -> str:
+def _normalize_suffix(modality: str, schema: Optional[SchemaInfo] = None) -> str:
     """Return a canonical BIDS suffix for a given modality string.
 
-    The DICOM ``SeriesDescription`` or user‑supplied modality labels can use a
-    wide range of capitalisation patterns or legacy terms (e.g. ``DTI`` instead
-    of ``dwi``).  This helper performs a case‑insensitive normalisation so later
-    logic only needs to work with the official BIDS suffixes.
+    Parameters
+    ----------
+    modality : str
+        Raw modality label captured from the DICOM ``SeriesDescription`` or the
+        user edited column in the GUI/TSV.  These labels can appear in arbitrary
+        casing (``FIELDmap``) or use legacy terms (``DTI``) which need to be
+        translated to official BIDS suffixes.
+    schema : SchemaInfo, optional
+        When available we consult the schema to locate a canonical suffix using
+        a case insensitive comparison.  This keeps the preview logic, the schema
+        renamer, and the heuristic builder perfectly aligned even when users
+        enter uncommon capitalisation patterns.
     """
 
-    m = modality.strip()
+    modality_clean = modality.strip()
+    modality_lower = modality_clean.lower()
+
+    # Hard-coded aliases cover the handful of well-known legacy spellings that
+    # are not present in the schema (for example ``DTI`` → ``dwi``).  Explicitly
+    # returning the canonical form avoids downstream comparisons having to worry
+    # about every possible capitalisation variant.
     alias = {
         "sbref": "sbref",
         "t2*": "T2star",
         "t2star": "T2star",
         "dti": "dwi",
     }
-    return alias.get(m.lower(), m)
+    if modality_lower in alias:
+        return alias[modality_lower]
+
+    # Fall back to the schema for case-insensitive matching.  This handles
+    # values like ``FieldMap`` which should be treated as ``fieldmap`` and keeps
+    # the proposed datatype rooted in the correct folder (``fmap`` in this case).
+    if schema is not None:
+        for suffix in schema.suffix_to_datatypes:
+            if suffix.lower() == modality_lower:
+                return suffix
+
+    # If nothing matched we return the cleaned modality as-is so legacy
+    # behaviour is preserved for custom labels that are not part of the schema.
+    return modality_clean
 
 
 def _choose_datatype(suffix: str, schema: SchemaInfo) -> str:
-    # Handle DWI derivatives first
+    """Determine the BIDS datatype folder for a given suffix."""
+
+    # Handle DWI derivatives first – these are always stored in ``derivatives/``.
     if suffix.lower() in ("adc", "fa", "tracew", "colfa", "expadc"):
         return "derivatives"
-    
+
+    # Primary lookup using the canonical suffix key.
     dts = schema.suffix_to_datatypes.get(suffix)
+
+    # Secondary lookup that is case-insensitive.  This is crucial for values
+    # such as ``FieldMap`` which should map to ``fmap`` instead of ``misc``.
+    if not dts:
+        suffix_lower = suffix.lower()
+        for key, value in schema.suffix_to_datatypes.items():
+            if key.lower() == suffix_lower:
+                dts = value
+                break
+
     if dts:
         pref = ("anat", "func", "dwi", "fmap", "perf", "pet", "meg", "eeg", "ieeg")
-        for p in pref:
-            if p in dts:
-                return p
+        for preferred in pref:
+            if preferred in dts:
+                return preferred
         return dts[0]
-    return {
+
+    # Legacy fallback table retains support for suffixes missing from the schema.
+    fallback = {
         "T1w": "anat", "T2w": "anat", "FLAIR": "anat", "T2star": "anat", "PD": "anat",
         "bold": "func", "sbref": "func", "physio": "func", "dwi": "dwi",
         "phasediff": "fmap", "fieldmap": "fmap", "magnitude1": "fmap", "magnitude2": "fmap", "epi": "fmap",
-    }.get(suffix, "misc")
+    }
+    if suffix in fallback:
+        return fallback[suffix]
+    return fallback.get(suffix.lower(), "misc")
 
 
 def propose_bids_basename(series: SeriesInfo, schema: SchemaInfo) -> Tuple[str, str]:
@@ -412,7 +457,7 @@ def propose_bids_basename(series: SeriesInfo, schema: SchemaInfo) -> Tuple[str, 
     identical BIDS names by using the full sanitized sequence as a fallback
     when no specific task hint is found.
     """
-    suffix = _normalize_suffix(series.modality)
+    suffix = _normalize_suffix(series.modality, schema)
     # Update the series object so any external tables reflect the normalized
     # modality used for the proposed BIDS name (prevents "bold" vs "func" mismatches
     # in the GUI).


### PR DESCRIPTION
## Summary
- normalize modality suffixes with case-insensitive schema lookups so fieldmaps resolve to the fmap datatype
- make datatype selection fall back to schema-insensitive matching with informative comments for clarity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3cc0991ac8326b1e06208cd6b843c