### PR TITLE
Ensure scanned metadata table sorts consistently by default

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -2359,6 +2359,20 @@ class BIDSManager(QMainWindow):
             )
             self.log_text.append(f"Sorted metadata table by {summary}.")
 
+    def _apply_default_mapping_sort(self) -> None:
+        """Sort the mapping table using the preferred default column order."""
+
+        if self.mapping_table.rowCount() <= 1:
+            return
+
+        default_order = [
+            ("BIDS_name", True),
+            ("subject", True),
+            ("session", True),
+            ("acq_time", True),
+        ]
+        self._apply_mapping_sort(default_order)
+
     @staticmethod
     def _coerce_sort_value(value: str) -> tuple[Any, ...]:
         """Return a comparable tuple for ``value`` suitable for sorting."""
@@ -2463,6 +2477,8 @@ class BIDSManager(QMainWindow):
         if self.inventory_process and self.inventory_process.state() != QProcess.NotRunning:
             return
 
+        # Reset the log panel so each scan starts with a clean slate.
+        self.log_text.clear()
         self.log_text.append("Starting TSV generation…")
         self.tsv_button.setEnabled(False)
         self.tsv_stop_button.setEnabled(True)
@@ -3065,7 +3081,12 @@ class BIDSManager(QMainWindow):
                 self.study_set.add(study)
                 self.mapping_table.setItem(r, 5, bids_item)
 
-                subj_item = QTableWidgetItem(_clean(row.get('subject')))
+                subject_value = _clean(row.get('subject'))
+                if not subject_value:
+                    # Legacy inventories only filled the first row; fall back to
+                    # the recorded given name so the column is complete.
+                    subject_value = _clean(row.get('GivenName'))
+                subj_item = QTableWidgetItem(subject_value)
                 subj_item.setFlags(subj_item.flags() | Qt.ItemIsEditable)
                 self.mapping_table.setItem(r, 6, subj_item)
 
@@ -3128,39 +3149,41 @@ class BIDSManager(QMainWindow):
                     'n_files': _clean(row.get('n_files')),
                     'acq_time': _clean(row.get('acq_time')),
                 })
-            self.log_text.append("Loaded TSV into mapping table.")
+        # Ensure the freshly loaded data starts in the preferred order.
+        self._apply_default_mapping_sort()
+        self.log_text.append("Loaded TSV into mapping table.")
 
-            # Apply always-exclude patterns before building lookup tables
-            self.applyExcludePatterns()
+        # Apply always-exclude patterns before building lookup tables
+        self.applyExcludePatterns()
 
-            # Build modality/sequence lookup for tree interactions
-            self._rebuild_lookup_maps()
+        # Build modality/sequence lookup for tree interactions
+        self._rebuild_lookup_maps()
 
-            self.populateModalitiesTree()
-            self.populateSpecificTree()
-            if getattr(self, 'last_rep_box', None) is not None and self.last_rep_box.isChecked():
-                self._onLastRepToggled(True)
+        self.populateModalitiesTree()
+        self.populateSpecificTree()
+        if getattr(self, 'last_rep_box', None) is not None and self.last_rep_box.isChecked():
+            self._onLastRepToggled(True)
 
-            # Populate naming table
-            self.naming_table.blockSignals(True)
-            self.naming_table.setRowCount(0)
-            name_df = df[["StudyDescription", "GivenName", "BIDS_name"]].copy()
-            name_df = name_df.drop_duplicates(subset=["StudyDescription", "BIDS_name"])
-            for _, row in name_df.iterrows():
-                nr = self.naming_table.rowCount()
-                self.naming_table.insertRow(nr)
-                sitem = QTableWidgetItem(_clean(row["StudyDescription"]))
-                sitem.setFlags(sitem.flags() & ~Qt.ItemIsEditable)
-                self.naming_table.setItem(nr, 0, sitem)
-                gitem = QTableWidgetItem(_clean(row["GivenName"]))
-                gitem.setFlags(gitem.flags() & ~Qt.ItemIsEditable)
-                self.naming_table.setItem(nr, 1, gitem)
-                bitem = QTableWidgetItem(_clean(row["BIDS_name"]))
-                bitem.setFlags(bitem.flags() | Qt.ItemIsEditable)
-                self.naming_table.setItem(nr, 2, bitem)
-            self.naming_table.blockSignals(False)
-            self._updateScanExistingEnabled()
-            self._updateMappingControlsEnabled()
+        # Populate naming table
+        self.naming_table.blockSignals(True)
+        self.naming_table.setRowCount(0)
+        name_df = df[["StudyDescription", "GivenName", "BIDS_name"]].copy()
+        name_df = name_df.drop_duplicates(subset=["StudyDescription", "BIDS_name"])
+        for _, row in name_df.iterrows():
+            nr = self.naming_table.rowCount()
+            self.naming_table.insertRow(nr)
+            sitem = QTableWidgetItem(_clean(row["StudyDescription"]))
+            sitem.setFlags(sitem.flags() & ~Qt.ItemIsEditable)
+            self.naming_table.setItem(nr, 0, sitem)
+            gitem = QTableWidgetItem(_clean(row["GivenName"]))
+            gitem.setFlags(gitem.flags() & ~Qt.ItemIsEditable)
+            self.naming_table.setItem(nr, 1, gitem)
+            bitem = QTableWidgetItem(_clean(row["BIDS_name"]))
+            bitem.setFlags(bitem.flags() | Qt.ItemIsEditable)
+            self.naming_table.setItem(nr, 2, bitem)
+        self.naming_table.blockSignals(False)
+        self._updateScanExistingEnabled()
+        self._updateMappingControlsEnabled()
         finally:
             self._loading_mapping_table = False
 


### PR DESCRIPTION
## Summary
- keep the subject column populated for every row in the scanned data inventory
- apply the default BIDS_name/subject/session/acq_time ordering when generating and loading the table
- clear the log output before starting a new scan so each run starts fresh

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4c982c2648326a310cf3e75558862