### PR TITLE
Align dicom inventory sorting and refresh scan logs

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -2463,6 +2463,9 @@ class BIDSManager(QMainWindow):
         if self.inventory_process and self.inventory_process.state() != QProcess.NotRunning:
             return
 
+        # Clear the log so each scan run starts with a fresh history for the
+        # user.
+        self.log_text.clear()
         self.log_text.append("Starting TSV generation…")
         self.tsv_button.setEnabled(False)
         self.tsv_stop_button.setEnabled(True)


### PR DESCRIPTION
## Summary
- populate the dicom inventory subject column on every row and sort the table by BIDS name, subject, session, and acquisition time
- clear the scanned data log view each time a new scan is started to show only relevant messages

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4d44141548326b5a9335e11f23e95