### PR TITLE
Limit IntendedFor lists to subsequent functional runs

### DIFF
--- a/bids_manager/post_conv_renamer.py
+++ b/bids_manager/post_conv_renamer.py
@@ -26,6 +26,9 @@ from pathlib import Path
 import json
 import re
 import sys
+from datetime import datetime
+from typing import Dict, List, Optional, Tuple
+
 
 # -----------------------------------------------------------------------------
 # Configuration: EDIT this path to point to your BIDS dataset
@@ -116,27 +119,222 @@ def _update_intended_for(root: Path, bids_root: Path) -> None:
     if not (fmap_dir.is_dir() and func_dir.is_dir()):
         return
 
-    # Collect paths of all functional images relative to the subject/session
-    # directory so that ``IntendedFor`` entries omit the ``sub-*`` prefix.
-    # Skip reference volumes (e.g. ``*_sbref``) as they should not appear in the
-    # ``IntendedFor`` lists.
-    func_files = [
-        f for f in sorted(func_dir.glob("*.nii*")) if "ref" not in f.name.lower()
-    ]
-    if not func_files:
+    def _parse_time_to_seconds(value: str) -> Optional[float]:
+        """Return seconds elapsed since midnight for a DICOM-style time string."""
+
+        if not value:
+            return None
+        text = value.strip()
+        if not text:
+            return None
+
+        # ``HH:MM:SS(.ffffff)`` → straightforward parsing.
+        if ":" in text:
+            parts = text.split(":")
+            if len(parts) < 2:
+                return None
+            hours = parts[0]
+            minutes = parts[1]
+            seconds = parts[2] if len(parts) > 2 else "0"
+        else:
+            # ``HHMMSS(.ffffff)`` – optional fractional part is appended.
+            if "." in text:
+                main, frac = text.split(".", 1)
+            else:
+                main, frac = text, ""
+            main = re.sub(r"\D", "", main)
+            if len(main) < 4:
+                return None
+            # Pad short strings (e.g. HHMM) with zeros for seconds.
+            main = main.ljust(6, "0")
+            hours, minutes, seconds = main[:2], main[2:4], main[4:6]
+            if frac:
+                seconds = f"{seconds}.{re.sub(r'\D', '', frac)}"
+
+        try:
+            h = int(hours)
+            m = int(minutes)
+            s = float(seconds)
+        except ValueError:
+            return None
+
+        return h * 3600 + m * 60 + s
+
+    def _parse_datetime_string(value: str) -> Optional[datetime]:
+        """Best-effort parser for the wide variety of DICOM date-time formats."""
+
+        if not value:
+            return None
+        text = value.strip()
+        if not text:
+            return None
+
+        try:
+            # ``datetime.fromisoformat`` handles ISO strings and fractional seconds.
+            return datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError:
+            pass
+
+        # Remove common separators so we can parse compact ``YYYYMMDDHHMMSS(.f)`` values.
+        compact = re.sub(r"[^0-9.]", "", text)
+        if len(compact) < 8:
+            return None
+
+        # Split main datetime and fractional seconds (if present).
+        if "." in compact:
+            main, frac = compact.split(".", 1)
+        else:
+            main, frac = compact, ""
+
+        if len(main) < 8:
+            return None
+
+        # Pad the main section so we always have YYYYMMDDHHMMSS for unpacking.
+        main = main.ljust(14, "0")
+        year = int(main[0:4])
+        month = int(main[4:6])
+        day = int(main[6:8])
+        hour = int(main[8:10])
+        minute = int(main[10:12])
+        second = int(main[12:14])
+        micro = int((frac + "000000")[:6]) if frac else 0
+        try:
+            return datetime(year, month, day, hour, minute, second, micro)
+        except ValueError:
+            return None
+
+    def _combine_date_time(date_value: str, time_value: str) -> Optional[datetime]:
+        """Construct a :class:`datetime` from independent DICOM date and time strings."""
+
+        if not date_value or not time_value:
+            return None
+        digits = re.sub(r"\D", "", date_value)
+        if len(digits) != 8:
+            return None
+        try:
+            year = int(digits[0:4])
+            month = int(digits[4:6])
+            day = int(digits[6:8])
+        except ValueError:
+            return None
+
+        seconds = _parse_time_to_seconds(time_value)
+        if seconds is None:
+            return None
+
+        hour = int(seconds // 3600)
+        minute = int((seconds % 3600) // 60)
+        sec_float = seconds - hour * 3600 - minute * 60
+        sec_int = int(sec_float)
+        micro = int(round((sec_float - sec_int) * 1_000_000))
+        try:
+            return datetime(year, month, day, hour, minute, sec_int, micro)
+        except ValueError:
+            return None
+
+    def _acquisition_order(meta: Dict[str, object], fallback_index: int) -> Tuple[int, float, int]:
+        """Return a sortable key representing the acquisition order for metadata."""
+
+        for key in ("AcquisitionDateTime", "SeriesDateTime"):
+            dt_val = meta.get(key)
+            dt = _parse_datetime_string(dt_val) if dt_val else None
+            if dt is not None:
+                return (0, dt.timestamp(), fallback_index)
+
+        date_keys = ("AcquisitionDate", "SeriesDate", "StudyDate")
+        time_keys = ("AcquisitionTime", "SeriesTime")
+        for date_key in date_keys:
+            date_val = meta.get(date_key)
+            if not date_val:
+                continue
+            for time_key in time_keys:
+                time_val = meta.get(time_key)
+                if not time_val:
+                    continue
+                dt = _combine_date_time(date_val, time_val)
+                if dt is not None:
+                    return (0, dt.timestamp(), fallback_index)
+
+        for time_key in time_keys:
+            time_val = meta.get(time_key)
+            if not time_val:
+                continue
+            seconds = _parse_time_to_seconds(time_val)
+            if seconds is not None:
+                return (1, seconds, fallback_index)
+
+        # Final fallback keeps stable ordering even when no timing metadata exist.
+        return (2, float(fallback_index), fallback_index)
+
+    def _matching_json(image_path: Path) -> Path:
+        """Return the expected JSON sidecar path for a NIfTI image."""
+
+        name = image_path.name
+        if name.endswith(".nii.gz"):
+            return image_path.with_name(name[:-7] + ".json")
+        if name.endswith(".nii"):
+            return image_path.with_suffix(".json")
+        return image_path.with_name(name + ".json")
+
+    # Build a sorted representation of functional runs together with their
+    # acquisition order.  SBRefs are excluded because they should never appear
+    # in the automatic ``IntendedFor`` entries.
+    func_info = []
+    for idx, func_file in enumerate(sorted(func_dir.glob("*.nii*"))):
+        if "ref" in func_file.name.lower():
+            continue
+        json_path = _matching_json(func_file)
+        if not json_path.exists():
+            order = (2, float(idx), idx)
+        else:
+            with open(json_path, "r", encoding="utf-8") as f:
+                func_meta = json.load(f)
+            order = _acquisition_order(func_meta, idx)
+        func_info.append(
+            {
+                "order": order,
+                "rel_path": func_file.relative_to(root).as_posix(),
+            }
+        )
+
+    if not func_info:
         return
 
-    rel_paths = [f.relative_to(root).as_posix() for f in func_files]
+    func_info.sort(key=lambda item: item["order"])
 
-    # Update each JSON sidecar under ``fmap`` with the collected paths.
-    for js in fmap_dir.glob("*.json"):
-        with open(js, "r", encoding="utf-8") as f:
-            meta = json.load(f)
-        meta["IntendedFor"] = rel_paths
-        with open(js, "w", encoding="utf-8") as f:
-            json.dump(meta, f, indent=4)
+    fmap_jsons = sorted(fmap_dir.glob("*.json"))
+    if not fmap_jsons:
+        return
+
+    fmap_info = []
+    for idx, fmap_json in enumerate(fmap_jsons):
+        with open(fmap_json, "r", encoding="utf-8") as f:
+            fmap_meta = json.load(f)
+        order = _acquisition_order(fmap_meta, idx)
+        fmap_info.append({"path": fmap_json, "meta": fmap_meta, "order": order})
+
+    fmap_info.sort(key=lambda item: item["order"])
+
+    # Walk through fieldmaps in acquisition order and collect all functional runs
+    # acquired after the current fmap but before the next one (if any).
+    for pos, fmap in enumerate(fmap_info):
+        current_key = fmap["order"]
+        next_key = fmap_info[pos + 1]["order"] if pos + 1 < len(fmap_info) else None
+
+        intended: List[str] = []
+        for func in func_info:
+            if func["order"] < current_key:
+                continue
+            if next_key is not None and func["order"] >= next_key:
+                continue
+            intended.append(func["rel_path"])
+
+        fmap_meta = fmap["meta"]
+        fmap_meta["IntendedFor"] = intended
+        with open(fmap["path"], "w", encoding="utf-8") as f:
+            json.dump(fmap_meta, f, indent=4)
             f.write("\n")
-        print(f"Updated IntendedFor in {js.relative_to(bids_root)}")
+        print(f"Updated IntendedFor in {fmap['path'].relative_to(bids_root)}")
 
 
 def add_intended_for(bids_root: Path) -> None:


### PR DESCRIPTION
## Summary
- update the post-conversion renamer to derive IntendedFor lists from acquisition order information
- parse acquisition timing metadata from fieldmap and functional JSON sidecars and map each fieldmap to only the following runs
- keep graceful fallbacks and detailed comments to preserve previous behaviour when metadata is missing

## Testing
- python -m compileall bids_manager/post_conv_renamer.py

------
https://chatgpt.com/codex/tasks/task_e_68e4dab6f4d483268b76d16410f70fe7