### PR TITLE
Fix editor menu visibility on macOS

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -2208,6 +2208,10 @@ class BIDSManager(QMainWindow):
 
         # Internal menu bar for Edit features
         menu = QMenuBar()
+        if sys.platform == "darwin":
+            # Force a widget-local menu on macOS so options remain visible
+            # within the Editor tab instead of moving to the global menu bar.
+            menu.setNativeMenuBar(False)
         menu.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         menu.setMaximumHeight(24)
         file_menu = menu.addMenu("File")


### PR DESCRIPTION
## Summary
- prevent the editor tab menu from moving into the macOS global menu bar by disabling native menu integration

## Testing
- not run (macOS UI-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914967818508326bf2c9fafc104b130)