### PR TITLE
Fix macOS OpenGL compatibility without breaking WebGL

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -152,14 +152,25 @@ except Exception:  # pragma: no cover - optional dependency
 
 if HAS_PYQTGRAPH and sys.platform == "darwin":
     # ``GLViewWidget`` relies on the fixed function pipeline which macOS no
-    # longer exposes when Qt requests a modern core profile.  Forcing a
-    # compatibility profile ensures the legacy ``glMatrixMode`` operations used
-    # by PyQtGraph continue to work on Apple devices.
-    fmt = QSurfaceFormat()
-    fmt.setProfile(QSurfaceFormat.CompatibilityProfile)
-    fmt.setRenderableType(QSurfaceFormat.OpenGL)
-    fmt.setVersion(2, 1)
-    QSurfaceFormat.setDefaultFormat(fmt)
+    # longer exposes when Qt requests a modern core profile.  Creating a
+    # compatibility surface format keeps those legacy operations working when
+    # rendering 3-D scenes while avoiding global changes that would otherwise
+    # break QtWebEngine/WebGL views.
+    _MAC_GL_SURFACE_FORMAT: Optional[QSurfaceFormat] = QSurfaceFormat()
+    _MAC_GL_SURFACE_FORMAT.setProfile(QSurfaceFormat.CompatibilityProfile)
+    _MAC_GL_SURFACE_FORMAT.setRenderableType(QSurfaceFormat.OpenGL)
+    _MAC_GL_SURFACE_FORMAT.setVersion(2, 1)
+else:
+    _MAC_GL_SURFACE_FORMAT = None
+
+
+def _maybe_apply_mac_gl_format(widget: Any) -> None:
+    """Apply the macOS compatibility OpenGL profile when available."""
+
+    if _MAC_GL_SURFACE_FORMAT is None:
+        return
+    if hasattr(widget, "setFormat"):
+        widget.setFormat(_MAC_GL_SURFACE_FORMAT)
 
 # Paths to images bundled with the application
 LOGO_FILE = Path(__file__).resolve().parent / "miscellaneous" / "images" / "Logo.png"
@@ -5261,6 +5272,7 @@ class Volume3DDialog(QDialog):
         # ``GLViewWidget`` renders using OpenGL so panning/zooming the scene does
         # not require recomputing the voxel subset on every interaction.
         self.view = gl.GLViewWidget()
+        _maybe_apply_mac_gl_format(self.view)
         self.view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.view.setBackgroundColor(self._canvas_bg)
         self.view.opts["distance"] = 200
@@ -6801,6 +6813,7 @@ class Surface3DDialog(QDialog):
         # ``GLViewWidget`` renders using OpenGL so panning/zooming the scene does
         # not require recomputing the mesh when interacting with the viewport.
         self.view = gl.GLViewWidget()
+        _maybe_apply_mac_gl_format(self.view)
         self.view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.view.setBackgroundColor(self._canvas_bg)
         self.view.opts["distance"] = 200
@@ -7557,6 +7570,7 @@ class FreeSurferSurfaceDialog(QDialog):
         layout = QVBoxLayout(self)
 
         self.view = gl.GLViewWidget()
+        _maybe_apply_mac_gl_format(self.view)
         self.view.setBackgroundColor(self._canvas_bg)
         self.view.opts["distance"] = 200
         self.view.opts["elevation"] = 20


### PR DESCRIPTION
## Summary
- add a macOS-specific compatibility OpenGL surface format and helper
- apply the compatibility format to each pyqtgraph GLViewWidget instance so the 3-D viewers work without altering the global Qt settings that QtWebEngine relies on

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b2dbad5588326922f70f3e6737284)