### PR TITLE
Ensure GL view fully repaints

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -76,7 +76,7 @@ from PyQt5.QtWidgets import (
     QHeaderView, QMessageBox, QAction, QSplitter, QDialog, QAbstractItemView,
     QMenuBar, QMenu, QSizePolicy, QComboBox, QSlider, QSpinBox,
     QCheckBox, QStyledItemDelegate, QDialogButtonBox, QListWidget, QScrollArea,
-    QToolButton
+    QToolButton, QOpenGLWidget,
 )
 from PyQt5.QtWebEngineWidgets import QWebEngineView
 from PyQt5.QtCore import (
@@ -5268,6 +5268,8 @@ class Volume3DDialog(QDialog):
             self.view.setFormat(gl_format)
         if gl_format_reset is not None:
             QSurfaceFormat.setDefaultFormat(gl_format_reset)
+        if hasattr(self.view, "setUpdateBehavior"):
+            self.view.setUpdateBehavior(QOpenGLWidget.NoPartialUpdate)
         self.view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.view.setBackgroundColor(self._canvas_bg)
         self.view.opts["distance"] = 200


### PR DESCRIPTION
## Summary
- add QOpenGLWidget dependency for 3D view
- force the GL view widget to use full repaints to avoid stale framebuffer content

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b6e89aec83268319b58383ca60d1)