### PR TITLE
Fix macOS OpenGL format for 3D viewer

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -158,6 +158,33 @@ ANCP_LAB_FILE = Path(__file__).resolve().parent / "miscellaneous" / "images" / "
 KAREL_IMG_FILE = Path(__file__).resolve().parent / "miscellaneous" / "images" / "Karel.jpeg"
 JOCHEM_IMG_FILE = Path(__file__).resolve().parent / "miscellaneous" / "images" / "Jochem.jpg"
 
+
+def _mac_compatibility_format() -> Optional[QSurfaceFormat]:
+    """Return an OpenGL compatibility profile suitable for pyqtgraph on macOS."""
+
+    if sys.platform != "darwin":
+        return None
+
+    gl_format = QSurfaceFormat()
+    gl_format.setRenderableType(QSurfaceFormat.OpenGL)
+    gl_format.setProfile(QSurfaceFormat.CompatibilityProfile)
+    gl_format.setVersion(2, 1)
+    return gl_format
+
+
+def _mac_webengine_format() -> Optional[QSurfaceFormat]:
+    """Return a hardware-accelerated OpenGL Core profile for Qt WebEngine on macOS."""
+
+    if sys.platform != "darwin":
+        return None
+
+    gl_format = QSurfaceFormat()
+    gl_format.setRenderableType(QSurfaceFormat.OpenGL)
+    gl_format.setProfile(QSurfaceFormat.CoreProfile)
+    # Qt WebEngine requires a 3.2+ Core profile; 4.1 matches the native macOS support
+    gl_format.setVersion(4, 1)
+    return gl_format
+
 # Directory used to store persistent user preferences
 PREF_DIR = Path(__file__).resolve().parent / "user_preferences"
 
@@ -5250,24 +5277,10 @@ class Volume3DDialog(QDialog):
 
         # ``GLViewWidget`` renders using OpenGL so panning/zooming the scene does
         # not require recomputing the voxel subset on every interaction.
-        gl_format_reset = None
-        gl_format = None
-        if sys.platform == "darwin":
-            gl_format_reset = QSurfaceFormat.defaultFormat()
-            gl_format = QSurfaceFormat()
-            gl_format.setRenderableType(QSurfaceFormat.OpenGL)
-            gl_format.setProfile(QSurfaceFormat.CompatibilityProfile)
-            gl_format.setVersion(2, 1)
-            # Apply a temporary compatibility profile so the GLViewWidget receives
-            # a context macOS accepts while leaving the default intact for
-            # QtWebEngine (used for WebGL in other parts of the app).
-            QSurfaceFormat.setDefaultFormat(gl_format)
-
+        gl_format = _mac_compatibility_format()
         self.view = gl.GLViewWidget()
         if gl_format is not None and hasattr(self.view, "setFormat"):
             self.view.setFormat(gl_format)
-        if gl_format_reset is not None:
-            QSurfaceFormat.setDefaultFormat(gl_format_reset)
         if hasattr(self.view, "setUpdateBehavior"):
             self.view.setUpdateBehavior(QOpenGLWidget.NoPartialUpdate)
         self.view.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
@@ -8994,6 +9007,9 @@ def main() -> None:
             pass
     if sys.platform == "darwin":
         QCoreApplication.setAttribute(Qt.AA_UseDesktopOpenGL)
+        gl_format = _mac_webengine_format()
+        if gl_format is not None:
+            QSurfaceFormat.setDefaultFormat(gl_format)
     app = QApplication(sys.argv)
     app.setStyle('Fusion')
     if ICON_FILE.exists():


### PR DESCRIPTION
## Summary
- keep a dedicated compatibility profile helper for the 3D viewer and add a macOS Core profile helper for Qt WebEngine
- request the Core profile as the application default on macOS to preserve WebEngine hardware acceleration while still using the compatibility format for pyqtgraph widgets

## Testing
- not run (GUI-dependent)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929bc294dc4832682c6459e1934f128)