### PR TITLE
Streamline suffix dictionary save workflow

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -1915,10 +1915,9 @@ class BIDSManager(QMainWindow):
         dict_layout.addWidget(self.seq_tabs_widget)
         dict_btn_row = QHBoxLayout()
         dict_btn_row.addStretch()
-        self.seq_apply_button = QPushButton("Apply")
-        self.seq_apply_button.clicked.connect(self.applySequenceDictionary)
-        dict_btn_row.addWidget(self.seq_apply_button)
         self.seq_save_button = QPushButton("Save")
+        # Saving the suffix dictionary also applies the changes immediately so
+        # users do not need a separate "Apply" step.
         self.seq_save_button.clicked.connect(self.saveSequenceDictionary)
         dict_btn_row.addWidget(self.seq_save_button)
         restore_btn = QPushButton("Restore defaults")
@@ -3899,8 +3898,6 @@ class BIDSManager(QMainWindow):
             button.setEnabled(enabled)
         for button in self.custom_remove_buttons.values():
             button.setEnabled(enabled)
-        if hasattr(self, "seq_apply_button"):
-            self.seq_apply_button.setEnabled(enabled)
         if hasattr(self, "seq_save_button"):
             self.seq_save_button.setEnabled(enabled)
 
@@ -4013,7 +4010,10 @@ class BIDSManager(QMainWindow):
             f"Updated suffix patterns in {self.seq_dict_file}",
         )
         self._refresh_suffix_dictionary()
+        # Applying the sequence dictionary immediately updates the scanned data
+        # table so users do not need to trigger "Save changes" separately.
         self.applySequenceDictionary()
+        self.applyMappingChanges()
 
     def restoreSequenceDefaults(self) -> None:
         dicom_inventory.restore_sequence_dictionary()


### PR DESCRIPTION
## Summary
- replace the separate apply/save controls on the suffix dictionary tab with a single save button that applies immediately
- ensure saving custom suffix patterns refreshes the scanned data table and persists the updated modality guesses without extra actions

## Testing
- not run (not requested)
