### PR TITLE
Fix macOS OpenGL compatibility for 3D viewer

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -102,6 +102,7 @@ from PyQt5.QtGui import (
     QPainter,
     QPen,
     QIcon,
+    QSurfaceFormat,
 )
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
@@ -9171,6 +9172,16 @@ def main() -> None:
             )
         except Exception:
             pass
+    if sys.platform == "darwin":
+        # macOS defaults to a Core OpenGL profile where fixed-function matrix
+        # calls like ``glMatrixMode`` are invalid. The 3-D viewer relies on
+        # pyqtgraph's fixed-function pipeline, so request a compatibility
+        # context before creating the Qt application.
+        fmt = QSurfaceFormat()
+        fmt.setRenderableType(QSurfaceFormat.OpenGL)
+        fmt.setProfile(QSurfaceFormat.CompatibilityProfile)
+        fmt.setVersion(2, 1)
+        QSurfaceFormat.setDefaultFormat(fmt)
     app = QApplication(sys.argv)
     app.setStyle('Fusion')
     if ICON_FILE.exists():


### PR DESCRIPTION
## Summary
- request a compatibility OpenGL context on macOS so pyqtgraph's 3-D viewer can use fixed-function APIs
- import QSurfaceFormat needed to configure the default context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931551f32748326bb1f004e3194f6c6)