### PR TITLE
Fix mesh shader compatibility on macOS OpenGL ES2

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -209,27 +209,36 @@ def _create_directional_light_shader():
     try:
         vertex = shader_mod.VertexShader(
             """
-            varying vec3 normal;
+            uniform mat4 u_mvp;
+            uniform mat3 u_normal;
+            attribute vec4 a_position;
+            attribute vec3 a_normal;
+            attribute vec4 a_color;
+            varying vec3 v_normal;
+            varying vec4 v_color;
             void main() {
-                normal = normalize(gl_NormalMatrix * gl_Normal);
-                gl_FrontColor = gl_Color;
-                gl_BackColor = gl_Color;
-                gl_Position = ftransform();
+                v_normal = normalize(u_normal * a_normal);
+                v_color = a_color;
+                gl_Position = u_mvp * a_position;
             }
             """
         )
         fragment = shader_mod.FragmentShader(
             """
+            #ifdef GL_ES
+            precision mediump float;
+            #endif
             uniform float lightDir[3];
             uniform float lightParams[2];
-            varying vec3 normal;
+            varying vec3 v_normal;
+            varying vec4 v_color;
             void main() {
-                vec3 norm = normalize(normal);
+                vec3 norm = normalize(v_normal);
                 vec3 lightVec = normalize(vec3(lightDir[0], lightDir[1], lightDir[2]));
                 float diffuse = max(dot(norm, lightVec), 0.0) * lightParams[0];
                 float ambient = lightParams[1];
                 float lighting = clamp(ambient + diffuse, 0.0, 1.0);
-                vec4 colour = gl_Color;
+                vec4 colour = v_color;
                 colour.rgb *= lighting;
                 gl_FragColor = colour;
             }
@@ -264,17 +273,24 @@ def _create_flat_color_shader():
     try:
         vertex = shader_mod.VertexShader(
             """
+            uniform mat4 u_mvp;
+            attribute vec4 a_position;
+            attribute vec4 a_color;
+            varying vec4 v_color;
             void main() {
-                gl_FrontColor = gl_Color;
-                gl_BackColor = gl_Color;
-                gl_Position = ftransform();
+                v_color = a_color;
+                gl_Position = u_mvp * a_position;
             }
             """
         )
         fragment = shader_mod.FragmentShader(
             """
+            #ifdef GL_ES
+            precision mediump float;
+            #endif
+            varying vec4 v_color;
             void main() {
-                gl_FragColor = gl_Color;
+                gl_FragColor = v_color;
             }
             """
         )
@@ -9182,4 +9198,3 @@ def main() -> None:
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
### Motivation
- Surface mesh rendering failed on macOS with shader compilation errors referencing deprecated fixed-function variables such as `gl_NormalMatrix`, `gl_Normal`, `gl_Color`, and `ftransform`, causing the 3D viewer to crash when drawing `GLMeshItem`.
- The goal is to make the custom mesh shaders compatible with pyqtgraph's ES2/modern GLSL path used on macOS by replacing legacy built-in inputs with explicit attributes/uniforms and varyings.

### Description
- Replace legacy fixed-function shader code in `_create_directional_light_shader` with ES2-compatible vertex and fragment shaders that use `uniform mat4 u_mvp`, `uniform mat3 u_normal`, `attribute vec4 a_position`, `attribute vec3 a_normal`, `attribute vec4 a_color`, and varyings `v_normal`/`v_color`.
- Add `#ifdef GL_ES` precision qualifiers to fragment shaders and switch to `u_mvp * a_position` for position transformation and `v_color` for color output.
- Make the same modern-GL adjustments in `_create_flat_color_shader` so the unlit shader uses `u_mvp`, `a_position`, `a_color`, and `v_color`.
- Commit updates to `bids_manager/gui.py` to provide shaders that compile successfully under the ES2 compatibility path used by macOS OpenGL drivers.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e2ccc6c308326bf02010ce8c880f4)