### PR TITLE
Fix translucent rendering depth in 3D viewers

### DIFF
--- a/bids_manager/gui.py
+++ b/bids_manager/gui.py
@@ -300,6 +300,33 @@ def _create_flat_color_shader():
     return shader_mod.ShaderProgram(None, [vertex, fragment], uniforms={})
 
 
+def _translucent_gl_options() -> dict:
+    """Return GL state options for reliable alpha blending."""
+
+    from OpenGL.GL import (
+        GL_BLEND,
+        GL_DEPTH_TEST,
+        GL_ONE_MINUS_SRC_ALPHA,
+        GL_SRC_ALPHA,
+    )
+
+    return {
+        "glEnable": GL_BLEND,
+        "glDisable": GL_DEPTH_TEST,
+        "glBlendFunc": (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA),
+        "glDepthMask": False,
+    }
+
+
+def _apply_translucent_options(item, alpha: float) -> None:
+    if item is None:
+        return
+    if alpha < 0.999:
+        item.setGLOptions(_translucent_gl_options())
+    else:
+        item.setGLOptions("opaque")
+
+
 _SLICE_ORIENTATIONS = (
     ("sagittal", 0, "Left", "Right"),
     ("coronal", 1, "Posterior", "Anterior"),
@@ -6715,7 +6742,7 @@ class Volume3DDialog(QDialog):
             self._scatter_item = gl.GLScatterPlotItem(pxMode=True)
             self.view.addItem(self._scatter_item)
         self._scatter_item.setData(pos=coords_mm, color=colors, size=float(self.point_slider.value()))
-        self._scatter_item.setGLOptions("translucent" if alpha < 0.999 else "opaque")
+        _apply_translucent_options(self._scatter_item, alpha)
 
         mins = coords_mm.min(axis=0)
         maxs = coords_mm.max(axis=0)
@@ -6851,7 +6878,7 @@ class Volume3DDialog(QDialog):
             self._mesh_item.setMeshData(meshdata=meshdata)
 
         self._update_light_shader()
-        self._mesh_item.setGLOptions("translucent" if alpha < 0.999 else "opaque")
+        _apply_translucent_options(self._mesh_item, alpha)
 
         mins = np.min(verts, axis=0)
         maxs = np.max(verts, axis=0)
@@ -7700,7 +7727,7 @@ class Surface3DDialog(QDialog):
         else:
             self._mesh_item.setMeshData(meshdata=meshdata)
         self._update_light_shader()
-        self._mesh_item.setGLOptions("translucent" if alpha < 0.999 else "opaque")
+        _apply_translucent_options(self._mesh_item, alpha)
 
         mins = np.min(clipped_verts, axis=0)
         maxs = np.max(clipped_verts, axis=0)
@@ -7873,7 +7900,7 @@ class FreeSurferSurfaceDialog(QDialog):
 
         self._apply_mesh_shader()
         alpha = self.opacity_slider.value() / 100.0
-        self._mesh_item.setGLOptions("translucent" if alpha < 0.999 else "opaque")
+        _apply_translucent_options(self._mesh_item, alpha)
         if not self._initialising:
             self.view.update()
 


### PR DESCRIPTION
### Motivation
- 3-D viewers exhibited inconsistent transparency when rotating meshes/point clouds due to blending/depth state, causing opacity to appear to disappear at certain angles.

### Description
- Add a shared helper ` _translucent_gl_options()` that returns a consistent GL state for alpha blending using `GL_BLEND`, disabling `GL_DEPTH_TEST`, `GL_SRC_ALPHA`, `GL_ONE_MINUS_SRC_ALPHA` and `glDepthMask=False`.
- Add ` _apply_translucent_options(item, alpha)` to centralise the decision between translucent GL options and opaque mode (`"opaque"`).
- Replace ad-hoc `setGLOptions("translucent" if alpha < 0.999 else "opaque")` calls with ` _apply_translucent_options(...)` for volume point clouds and surface meshes in `Volume3DDialog`, for surface meshes in `Surface3DDialog`, and for FreeSurfer meshes in `FreeSurferSurfaceDialog` in `bids_manager/gui.py`.

### Testing
- No automated tests were executed for this change.
- Change is limited to rendering state configuration in `bids_manager/gui.py` and aimed at improving runtime visual behaviour (manual verification recommended in an environment with `pyqtgraph`/OpenGL).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e342d9f1c8326a255345d0272f90a)