### PR TITLE
feat: detect non-image (no-pixel-data) DICOM series + physio fixes

### DIFF
--- a/bidsmgr/cli/scan.py
+++ b/bidsmgr/cli/scan.py
@@ -920,7 +920,78 @@ def _augment_dataframe(
                     annotated_issues.append(anomaly)
                     df.at[df_idx, "proposed_issues"] = " | ".join(annotated_issues)
 
+    _flag_nonimage_rows(df)
     return df
+
+
+# Marker prepended to ``proposed_issues`` for a DERIVED non-image series.
+# The GUI inventory model keys on the leading ``NONIMAGE_ISSUE_TOKEN``
+# substring to paint the row's "not an image" highlight, so keep the two
+# in sync (mirrors how the abort highlight keys on ``suspected_abort``).
+NONIMAGE_ISSUE_TOKEN = "non-image series"
+NONIMAGE_ISSUE = (
+    "non-image series: the DICOM headers carry no pixel data "
+    "(Rows/Columns absent), so dcm2niix cannot convert it to NIfTI. "
+    "This is typically a scanner-derived object such as a Siemens "
+    "diffusion TENSOR map. Excluded from conversion."
+)
+
+
+def _is_nonimage_flag(val: object) -> bool:
+    """True only when the internal ``_has_pixel_data`` flag is explicitly
+    False. NaN / blank / True (fmap-collapsed rows, EEG/MEG rows, real
+    images) are treated as images."""
+    if val is True or val is False:
+        return val is False
+    return str(val).strip().lower() in ("false", "0")
+
+
+def _is_physio_row(df: pd.DataFrame, idx: object) -> bool:
+    """True for Siemens CMRR ``_PhysioLog.dcm`` rows.
+
+    Physio DICOMs carry no Image Pixel module (no Rows/Columns) just like a
+    DERIVED non-image object, but unlike one they ARE convertible -- the
+    ``PhysioDcmBackend`` (bidsphysio) turns them into ``_physio.tsv.gz`` +
+    ``_physio.json``. So they must be exempt from the non-image exclusion.
+    Identified by the ``physio`` suffix the converter dispatches on, with
+    ``modality`` / basename fallbacks for robustness."""
+    def _cell(col: str) -> str:
+        return str(df.at[idx, col]).strip().lower() if col in df.columns else ""
+
+    return (
+        _cell("bids_guess_suffix") == "physio"
+        or _cell("modality") == "physio"
+        or _cell("proposed_basename").endswith("_physio")
+    )
+
+
+def _flag_nonimage_rows(df: pd.DataFrame) -> None:
+    """Exclude + annotate DICOM series that carry no pixel data.
+
+    A series whose DICOMs lack the Image Pixel module (Rows/Columns) is a
+    DERIVED non-image object (commonly a Siemens diffusion TENSOR map, also
+    structured reports / spectroscopy frames). dcm2niix cannot turn it into
+    a NIfTI, so instead of letting the converter attempt it and fail with a
+    cryptic ``rc=2`` we flag the row here: force ``bids_guess_skip`` /
+    ``include=0`` so it is never converted, and prepend a clear reason to
+    ``proposed_issues`` so it surfaces in the inventory table highlighted as
+    "not an actual image". Operates on the internal ``_has_pixel_data``
+    column (stamped by ``inventory.mri_dicom``, dropped from the final TSV).
+    """
+    if "_has_pixel_data" not in df.columns:
+        return
+    for df_idx in df.index:
+        if not _is_nonimage_flag(df.at[df_idx, "_has_pixel_data"]):
+            continue
+        # Physio rows have no pixel data but ARE convertible (bidsphysio).
+        if _is_physio_row(df, df_idx):
+            continue
+        df.at[df_idx, "bids_guess_skip"] = True
+        df.at[df_idx, "include"] = 0
+        existing = str(df.at[df_idx, "proposed_issues"] or "").strip()
+        df.at[df_idx, "proposed_issues"] = (
+            f"{NONIMAGE_ISSUE} | {existing}" if existing else NONIMAGE_ISSUE
+        )
 
 
 def _probe_anomaly(

--- a/bidsmgr/converter/backends/physio_dcm.py
+++ b/bidsmgr/converter/backends/physio_dcm.py
@@ -131,7 +131,23 @@ class PhysioDcmBackend:
                     duration_s=time.monotonic() - t0,
                 )
 
-        staged = sorted(output_dir.glob(f"{task.basename}*"))
+        # bidsphysio inserts a ``_recording-<label>`` infix *before* the
+        # ``_physio`` suffix when a recording carries multiple sampling
+        # rates, so the emitted names are
+        # ``<stem>_recording-<label>_physio.{tsv.gz,json}`` rather than the
+        # exact ``<basename>`` (= ``<stem>_physio``). Glob on the stem so we
+        # detect both the single-rate (``<stem>_physio.*``) and multi-rate
+        # forms; ``*_physio.`` keeps us from picking up a sibling imaging
+        # file (e.g. the accompanying ``_bold.nii.gz``) in the same dir.
+        stem = (
+            task.basename[: -len("_physio")]
+            if task.basename.endswith("_physio")
+            else task.basename
+        )
+        staged = sorted(
+            set(output_dir.glob(f"{stem}*_physio.tsv.gz"))
+            | set(output_dir.glob(f"{stem}*_physio.json"))
+        )
         if not staged:
             return ConvertResult(
                 task=task, success=False,

--- a/bidsmgr/gui/delegates/row_state.py
+++ b/bidsmgr/gui/delegates/row_state.py
@@ -39,9 +39,9 @@ def paint_row_state(
 ) -> None:
     """Tint the cell's background according to ``row_state``.
 
-    Recognised values: ``"selected"``, ``"warn"``, ``"err"``, ``"skip"``.
-    Anything else (including ``None`` / ``""``) is a no-op so the model
-    can omit the role for non-special rows.
+    Recognised values: ``"selected"``, ``"warn"``, ``"err"``, ``"skip"``,
+    ``"noimg"``. Anything else (including ``None`` / ``""``) is a no-op so
+    the model can omit the role for non-special rows.
     """
     if not row_state:
         return
@@ -54,6 +54,11 @@ def paint_row_state(
         painter.fillRect(option.rect, rgba(pal["error"], 0.06))
     elif row_state == "skip":
         painter.fillRect(option.rect, QColor(pal["bg"]))
+    elif row_state == "noimg":
+        # DERIVED non-image object (no pixel data; excluded from convert).
+        # A distinct teal wash so it reads as "flagged / informational"
+        # rather than the de-emphasised grey of an ordinary skip.
+        painter.fillRect(option.rect, rgba(pal["teal"], 0.14))
 
 
 def paint_highlight(

--- a/bidsmgr/gui/models/inventory.py
+++ b/bidsmgr/gui/models/inventory.py
@@ -214,6 +214,17 @@ class InventoryTableModel(QAbstractTableModel):
         if role == HIGHLIGHT_ROLE:
             return self._highlight_aborts and self.is_row_aborted(row)
 
+        # Hovering any cell of a flagged row surfaces the scanner's
+        # ``proposed_issues`` (e.g. the "non-image series" reason) so the
+        # user sees *why* a row is highlighted without unhiding the issues
+        # column. Newline-split the `` | ``-joined notes for readability.
+        if role == Qt.ItemDataRole.ToolTipRole:
+            if "proposed_issues" in self._df.columns:
+                issues = str(self._df.at[row, "proposed_issues"] or "").strip()
+                if issues:
+                    return issues.replace(" | ", "\n")
+            return None
+
         # Checkbox and status cells communicate via PAYLOAD_ROLE instead
         # of DisplayRole; they have no text body.
         if spec.role == "checkbox":
@@ -764,6 +775,17 @@ class InventoryTableModel(QAbstractTableModel):
         Drives the row tint applied by every delegate. Selection is
         applied by the view at paint time, not stored here.
         """
+        # Non-image DERIVED objects (no pixel data; e.g. a Siemens TENSOR
+        # map) are flagged by the scanner via the ``non-image series``
+        # token in ``proposed_issues`` (see ``cli/scan.NONIMAGE_ISSUE_TOKEN``).
+        # They are excluded from conversion (include=0) but must still read
+        # as a deliberate, highlighted "not an image" state rather than a
+        # de-emphasised skip — so this check wins over the include check.
+        if "proposed_issues" in self._df.columns:
+            issues_l = str(self._df.at[row, "proposed_issues"] or "").lower()
+            if "non-image series" in issues_l:
+                return "noimg"
+
         if not self._read_include(row):
             return "skip"
 
@@ -807,6 +829,8 @@ class InventoryTableModel(QAbstractTableModel):
         keep their distinct icon.
         """
         state = self._row_states[row]
+        if state == "noimg":
+            return "noimg"
         if state == "skip":
             return "skip"
         if state == "err":

--- a/bidsmgr/gui/widgets/status_badge.py
+++ b/bidsmgr/gui/widgets/status_badge.py
@@ -28,6 +28,7 @@ KIND_CHAR: dict[str, str] = {
     "phys": "P",
     "skip": "−",
     "info": "i",
+    "noimg": "⊘",   # DERIVED non-image object (no pixel data; not convertible)
 }
 
 # Background color: which palette token to tint, and at what alpha.
@@ -38,12 +39,14 @@ KIND_BG_TOKEN: dict[str, tuple[str, float]] = {
     "phys": ("accent",  0.18),
     "skip": ("muted",   0.20),
     "info": ("accent",  0.18),
+    "noimg": ("teal",   0.20),
 }
 
 # Foreground (glyph) color token.
 KIND_FG_TOKEN: dict[str, str] = {
     "ok": "success", "warn": "warning", "err": "error",
     "phys": "accent", "skip": "dim", "info": "accent",
+    "noimg": "teal",
 }
 
 

--- a/bidsmgr/inventory/mri_dicom.py
+++ b/bidsmgr/inventory/mri_dicom.py
@@ -171,6 +171,13 @@ def _read_one(fpath: str, root_dir: Path) -> Optional[dict]:
     folder = root_dir.name if rel == "." else rel
     series = str(getattr(ds, "SeriesDescription", "n/a")).strip()
     uid = str(getattr(ds, "SeriesInstanceUID", ""))
+    # Pixel presence: a real image carries the Image Pixel module's
+    # Rows + Columns (0028,0010 / 0028,0011). DERIVED non-image objects
+    # (a Siemens diffusion TENSOR map, a structured report, a
+    # spectroscopy frame, ...) omit them and dcm2niix cannot turn them
+    # into a NIfTI. We OR this across a series' files downstream so a
+    # series counts as an image if ANY of its files carries pixels.
+    has_pixels = ("Rows" in ds) and ("Columns" in ds)
     img_list = normalize_image_type(getattr(ds, "ImageType", None))
     img3 = classify_fieldmap_type(img_list)
     if not img3:
@@ -206,6 +213,7 @@ def _read_one(fpath: str, root_dir: Path) -> Optional[dict]:
         "study_uid": study_uid,
         "study_date": study_date,
         "study_time": study_time,
+        "has_pixels": has_pixels,
         "demo": {
             "GivenName": given,
             "FamilyName": family_name,
@@ -249,6 +257,10 @@ def scan_dicoms_long(
     imgtypes: dict = defaultdict(lambda: defaultdict(dict))
     sessset: dict = defaultdict(lambda: defaultdict(set))
     file_dirs: dict = defaultdict(lambda: defaultdict(dict))
+    # Per-series pixel presence: True once any file in the series carries
+    # an Image Pixel module (Rows/Columns). Series with no pixel-bearing
+    # file are DERIVED non-image objects dcm2niix cannot convert.
+    haspix: dict = defaultdict(lambda: defaultdict(dict))
     # study-level metadata (per series): subj_key -> folder -> (series,uid) -> study tuple
     study_uids: dict = defaultdict(lambda: defaultdict(dict))
     # all distinct study tuples seen for each subject (for session inference).
@@ -281,6 +293,9 @@ def scan_dicoms_long(
             acq_times[subj_key][folder][key] = res["acq_time"]
         if key not in file_dirs[subj_key][folder]:
             file_dirs[subj_key][folder][key] = res["file_dir"]
+        haspix[subj_key][folder][key] = (
+            haspix[subj_key][folder].get(key, False) or bool(res.get("has_pixels"))
+        )
         # Track every DICOM file path per UID for later per-series probe.
         uid_str = res["uid"]
         if uid_str:
@@ -397,6 +412,12 @@ def scan_dicoms_long(
                     "study_date": study_tuple[1],
                     "study_time": study_tuple[2],
                     "_source_dir": file_dirs[subj_key][folder].get((series, uid), ""),
+                    # Internal flag (leading underscore -> dropped from the
+                    # final TSV by ``cli/scan._unified_column_order``).
+                    # Consumed by ``cli/scan`` to flag/exclude non-image
+                    # DERIVED objects (e.g. Siemens TENSOR) that dcm2niix
+                    # cannot convert.
+                    "_has_pixel_data": haspix[subj_key][folder].get((series, uid), False),
                     **demo[subj_key],
                 })
 

--- a/bidsmgr/vendor/README.md
+++ b/bidsmgr/vendor/README.md
@@ -52,8 +52,19 @@ entirely.
    (`from bidsphysio.base.bidsphysio import ...`) to relative
    (`from ..base.bidsphysio import ...`) so the tree relocates
    cleanly under `bidsmgr.vendor`.
-3. No behavioural changes. Every function and class body is
-   verbatim. Original per-file MIT headers are preserved.
+3. One performance fix in `base/bidsphysio.py`:
+   `PhysioSignal.plug_missing_data` was rewritten from the upstream
+   one-insertion-at-a-time loop (each step a full `np.concatenate` plus
+   a re-scan from index 0, i.e. O(n^2)) to a vectorised single-pass
+   build. The upstream version hangs for minutes on large CMRR logs
+   (a real 22M-sample ECG with many gaps); the rewrite handles 1M
+   samples / ~1M gaps in well under a second. Output is identical to
+   the original for every input where the original actually fills gaps;
+   it additionally fixes an upstream `np.argmax` edge bug that left a
+   gap in the very first sampling interval unfilled. Covered by
+   `tests/unit/test_bidsphysio_plug_missing_data.py`.
+4. Otherwise no behavioural changes. Every other function and class
+   body is verbatim. Original per-file MIT headers are preserved.
 
 **What's in the tree:**
 

--- a/bidsmgr/vendor/bidsphysio/base/bidsphysio.py
+++ b/bidsmgr/vendor/bidsphysio/base/bidsphysio.py
@@ -149,30 +149,60 @@ class PhysioSignal(object):
         """
         Function to plug "missing_value" (NaN, by default) wherever the
         signal was not recorded.
+
+        bids-manager change (vendored): the upstream implementation inserted
+        one missing sample at a time, each insertion doing a full
+        ``np.concatenate`` (O(n) copy of the whole signal) followed by a
+        re-scan from the start -- O(n^2) overall, which hangs for minutes on
+        large CMRR logs (e.g. a 22M-sample ECG with many gaps). This is a
+        fully vectorised rewrite that produces the identical output in a
+        single pass / single allocation. See ``bidsmgr/vendor/README.md``.
         """
 
         # The time increment between samples:
-        dt = 1/self.samples_per_second
+        dt = 1 / self.samples_per_second
 
-        # The following finds the first index for which the difference between
-        #   consecutive elements is larger than dt (plus a small rounding error)
-        # (argmax stops at the first "True"; if it doesn't find any, it returns 0):
-        i = np.argmax( np.ediff1d(self.sampling_times) > dt*(1.001) )
-        while i != 0:
-            # new time array, which adds the missing timepoint:
-            self.sampling_times = np.concatenate(
-                # Note: np.concatenate takes a list as argument, so you need (...)
-                (self.sampling_times[:i+1], [self.sampling_times[i]+dt], self.sampling_times[i+1:])
-            )
-            # new signal array, which adds a "missing_value" at the missing timepoint:
-            self.signal = np.concatenate(
-                # Note: np.concatenate takes a list as argument, so you need (...)
-                (self.signal[:i+1], [missing_value], self.signal[i+1:])
-            )
-            # check to see if we are done:
-            i = np.argmax( np.ediff1d(self.sampling_times) > dt*(1.001) )
+        times = np.asarray(self.sampling_times, dtype=float)
+        signal = np.asarray(self.signal)
+        n = times.size
+        if n < 2:
+            self.samples_count = int(signal.size)
+            return
 
-        self.samples_count = len( self.signal )
+        diffs = np.diff(times)
+        gap_mask = diffs > dt * 1.001
+        # Number of missing samples to insert AFTER each original sample.
+        # ``ceil(diff/dt - 1.001)`` matches the upstream loop's count exactly:
+        # it inserts at ``t+dt, t+2dt, ...`` until the residual gap is <= dt.
+        inserts = np.zeros(n, dtype=np.int64)  # inserts[-1] stays 0 (no gap after last)
+        inserts[:-1][gap_mask] = np.ceil(
+            diffs[gap_mask] / dt - 1.001
+        ).astype(np.int64)
+
+        total = int(inserts.sum())
+        if total == 0:
+            self.samples_count = int(signal.size)
+            return
+
+        out_len = n + total
+        block = 1 + inserts                       # output slots each original sample owns
+        orig_pos = np.cumsum(block) - block       # output index of each original sample
+
+        out_times = np.empty(out_len, dtype=float)
+        out_signal = np.full(out_len, missing_value, dtype=signal.dtype)
+        out_times[orig_pos] = times
+        out_signal[orig_pos] = signal
+
+        # Inserted slots get times ``t_prev + dt * k`` (k = 1, 2, ...).
+        base = np.repeat(times, block)            # preceding original time per slot
+        within = np.arange(out_len) - np.repeat(orig_pos, block)  # 0 at original, 1.. at inserts
+        inserted = np.ones(out_len, dtype=bool)
+        inserted[orig_pos] = False
+        out_times[inserted] = (base + dt * within)[inserted]
+
+        self.sampling_times = out_times
+        self.signal = out_signal
+        self.samples_count = out_len
 
     @classmethod
     def matching_trigger_signal(cls, mysignal, trigger_s):

--- a/tests/gui/test_inventory_model.py
+++ b/tests/gui/test_inventory_model.py
@@ -262,6 +262,51 @@ def test_status_kind_ok_for_valid_mri_row() -> None:
     assert model.data(model.index(0, status_col), PAYLOAD_ROLE) == "ok"
 
 
+def test_row_state_noimg_for_nonimage_series() -> None:
+    """A DERIVED non-image series (flagged by the scanner with the
+    ``non-image series`` token) reads as ``noimg`` — taking priority over
+    the ``skip`` it would otherwise get for being excluded (include=0)."""
+    df = make_df([_ok_row(
+        include=0,
+        bids_guess_skip=True,
+        proposed_issues=(
+            "non-image series: the DICOM headers carry no pixel data "
+            "(Rows/Columns absent), so dcm2niix cannot convert it. "
+            "Excluded from conversion."
+        ),
+    )])
+    model = InventoryTableModel(df)
+    assert model.data(model.index(0, 0), ROW_STATE_ROLE) == "noimg"
+
+
+def test_status_kind_noimg_for_nonimage_series() -> None:
+    df = make_df([_ok_row(
+        include=0, bids_guess_skip=True,
+        proposed_issues="non-image series: no pixel data; excluded.",
+    )])
+    model = InventoryTableModel(df)
+    status_col = next(i for i, c in enumerate(COLUMNS) if c.key == "status")
+    assert model.data(model.index(0, status_col), PAYLOAD_ROLE) == "noimg"
+
+
+def test_tooltip_surfaces_proposed_issues() -> None:
+    """Hovering any cell of a flagged row shows the scanner's reason."""
+    df = make_df([_ok_row(
+        proposed_issues="non-image series: no pixel data | trivial: few files",
+    )])
+    model = InventoryTableModel(df)
+    tip = model.data(model.index(0, 1), Qt.ItemDataRole.ToolTipRole)
+    assert tip is not None and "non-image series" in tip
+    # `` | ``-joined notes are split onto separate lines for readability.
+    assert "\n" in tip
+
+
+def test_no_tooltip_when_no_issues() -> None:
+    df = make_df([_ok_row(proposed_issues="")])
+    model = InventoryTableModel(df)
+    assert model.data(model.index(0, 1), Qt.ItemDataRole.ToolTipRole) is None
+
+
 def test_include_payload_reads_dataframe() -> None:
     df = make_df([_ok_row(include=1), _ok_row(include=0)])
     model = InventoryTableModel(df)

--- a/tests/unit/test_bidsphysio_plug_missing_data.py
+++ b/tests/unit/test_bidsphysio_plug_missing_data.py
@@ -1,0 +1,104 @@
+"""Tests for the vendored bidsphysio ``PhysioSignal.plug_missing_data`` fix.
+
+The upstream implementation inserted one missing sample at a time, each
+insertion doing a full ``np.concatenate`` plus a re-scan from index 0 --
+O(n^2), which hangs for minutes on large CMRR logs (a real 22M-sample ECG
+with many gaps). bids-manager replaced it with a vectorised single-pass
+rewrite. These tests lock in:
+
+* identical output to the original algorithm whenever the original works
+  (i.e. the first interval is not itself a gap -- see note below),
+* a regular time grid with the original samples preserved and gaps filled
+  with NaN, for arbitrary inputs, and
+* that the pathological many-gap case completes quickly (no O(n^2) hang).
+
+Note on the upstream edge bug: the original used
+``np.argmax(diffs > dt*1.001)`` whose result is ``0`` both for "no gap" and
+"first gap at index 0", and its ``while i != 0`` loop then treated index-0
+gaps as "done" -- so a gap in the very first interval was silently left
+unfilled. The vectorised rewrite fills those too (correct behaviour); the
+identical-output test therefore only compares on inputs whose first interval
+is not a gap, which is the case for real recordings.
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from bidsmgr.vendor.bidsphysio.base.bidsphysio import PhysioSignal
+
+
+def _naive_plug(times, signal, sps, missing=np.nan):
+    """The original O(n^2) algorithm, verbatim, as a reference oracle."""
+    dt = 1 / sps
+    t = np.array(times, dtype=float)
+    arr = np.array(signal, dtype=float)
+    i = np.argmax(np.ediff1d(t) > dt * 1.001)
+    while i != 0:
+        t = np.concatenate((t[: i + 1], [t[i] + dt], t[i + 1:]))
+        arr = np.concatenate((arr[: i + 1], [missing], arr[i + 1:]))
+        i = np.argmax(np.ediff1d(t) > dt * 1.001)
+    return t, arr
+
+
+def _plug(times, signal, sps=1.0):
+    ps = PhysioSignal(
+        label="x", signal=np.array(signal, dtype=float),
+        samples_per_second=sps, sampling_times=np.array(times, dtype=float),
+    )
+    ps.plug_missing_data()
+    return ps
+
+
+def test_identical_to_original_when_first_interval_is_not_a_gap() -> None:
+    rng = np.random.default_rng(1)
+    for _ in range(300):
+        n = rng.integers(4, 50)
+        rest = np.sort(rng.choice(np.arange(2, n * 2), size=n - 2, replace=False)).astype(float)
+        times = np.concatenate(([0.0, 1.0], rest))  # first interval = 1 (no leading gap)
+        signal = rng.normal(size=len(times))
+        ref_t, ref_s = _naive_plug(times, signal, 1.0)
+        ps = _plug(times, signal)
+        assert np.allclose(ps.sampling_times, ref_t)
+        assert np.array_equal(np.isnan(ps.signal), np.isnan(ref_s))
+        assert np.allclose(ps.signal[~np.isnan(ps.signal)], ref_s[~np.isnan(ref_s)])
+
+
+def test_always_regular_grid_with_originals_preserved() -> None:
+    rng = np.random.default_rng(2)
+    for _ in range(300):
+        n = rng.integers(3, 50)
+        times = np.sort(rng.choice(np.arange(0, n * 2), size=n, replace=False)).astype(float)
+        signal = rng.normal(size=n)
+        ps = _plug(times, signal)
+        assert np.allclose(np.diff(ps.sampling_times), 1.0)  # regular grid
+        assert np.allclose(ps.signal[~np.isnan(ps.signal)], signal)  # originals kept
+
+
+def test_no_op_when_already_regular() -> None:
+    ps = _plug([0.0, 1.0, 2.0, 3.0], [10.0, 11.0, 12.0, 13.0])
+    assert np.array_equal(ps.sampling_times, [0, 1, 2, 3])
+    assert np.array_equal(ps.signal, [10, 11, 12, 13])
+    assert ps.samples_count == 4
+
+
+def test_fills_single_and_multi_sample_gaps() -> None:
+    # gap of 1 missing (1->3) and a wide gap of 3 missing (3->7)
+    ps = _plug([0.0, 1.0, 3.0, 7.0], [0.0, 1.0, 3.0, 7.0])
+    assert np.allclose(ps.sampling_times, [0, 1, 2, 3, 4, 5, 6, 7])
+    nan_positions = np.isnan(ps.signal)
+    assert list(np.nonzero(nan_positions)[0]) == [2, 4, 5, 6]
+
+
+def test_large_many_gap_input_does_not_hang() -> None:
+    """1M samples with ~1M gaps: the old O(n^2) loop would hang for minutes."""
+    rng = np.random.default_rng(3)
+    times = np.sort(rng.choice(np.arange(0, 2_000_000), size=1_000_000, replace=False)).astype(float)
+    signal = rng.normal(size=1_000_000)
+    t0 = time.monotonic()
+    ps = _plug(times, signal)
+    elapsed = time.monotonic() - t0
+    assert elapsed < 5.0, f"plug_missing_data too slow ({elapsed:.1f}s) - O(n^2) regression?"
+    assert np.allclose(np.diff(ps.sampling_times), 1.0)

--- a/tests/unit/test_nonimage_detection.py
+++ b/tests/unit/test_nonimage_detection.py
@@ -1,0 +1,195 @@
+"""Tests for non-image (no-pixel-data) DICOM detection.
+
+A DICOM series whose files carry no Image Pixel module (Rows/Columns) is a
+DERIVED non-image object (e.g. a Siemens diffusion ``TENSOR`` map or a
+``PhoenixZIPReport``). dcm2niix cannot convert it to NIfTI, so the scanner
+flags it: excluded from conversion (``include=0`` / ``bids_guess_skip``)
+with a ``non-image series`` note in ``proposed_issues`` so it surfaces in
+the inventory table highlighted rather than failing dcm2niix with ``rc=2``.
+
+Covers the engine layer:
+* ``mri_dicom._read_one`` stamps ``has_pixels`` per file.
+* ``mri_dicom.scan_dicoms_long`` aggregates it into the internal
+  ``_has_pixel_data`` column (OR across a series' files).
+* ``cli/scan._flag_nonimage_rows`` excludes + annotates non-image rows.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pydicom
+import pytest
+from pydicom.dataset import FileDataset, FileMetaDataset
+from pydicom.uid import ExplicitVRLittleEndian, MRImageStorage, generate_uid
+
+from bidsmgr.cli.scan import (
+    NONIMAGE_ISSUE_TOKEN,
+    _flag_nonimage_rows,
+    _is_nonimage_flag,
+)
+from bidsmgr.inventory.mri_dicom import _read_one, scan_dicoms_long
+
+
+# ---------------------------------------------------------------------------
+# Synthetic DICOM helper
+# ---------------------------------------------------------------------------
+
+
+def _write_dicom(
+    path: Path,
+    *,
+    with_pixels: bool,
+    series_desc: str,
+    series_uid: str,
+    patient_id: str = "P1",
+    patient_name: str = "Doe^Jane",
+) -> None:
+    """Write a minimal DICOM with or without the Image Pixel module."""
+    fm = FileMetaDataset()
+    fm.MediaStorageSOPClassUID = MRImageStorage
+    fm.MediaStorageSOPInstanceUID = generate_uid()
+    fm.TransferSyntaxUID = ExplicitVRLittleEndian
+    ds = FileDataset(str(path), {}, file_meta=fm, preamble=b"\0" * 128)
+    ds.PatientID = patient_id
+    ds.PatientName = patient_name
+    ds.Modality = "MR"
+    ds.SeriesDescription = series_desc
+    ds.SeriesInstanceUID = series_uid
+    ds.StudyInstanceUID = generate_uid()
+    ds.SOPInstanceUID = fm.MediaStorageSOPInstanceUID
+    if with_pixels:
+        ds.ImageType = ["ORIGINAL", "PRIMARY", "M", "ND"]
+        ds.Rows = 4
+        ds.Columns = 4
+        ds.BitsAllocated = 16
+        ds.PixelData = (b"\x00\x00") * 16
+    else:
+        # DERIVED non-image object: no Rows/Columns, no PixelData.
+        ds.ImageType = ["DERIVED", "PRIMARY", "DIFFUSION", "TENSOR", "ND"]
+    ds.save_as(str(path), enforce_file_format=True)
+
+
+# ---------------------------------------------------------------------------
+# _read_one pixel detection
+# ---------------------------------------------------------------------------
+
+
+def test_read_one_detects_pixels(tmp_path: Path) -> None:
+    p = tmp_path / "img.dcm"
+    _write_dicom(p, with_pixels=True, series_desc="t1_mprage", series_uid="1.1")
+    res = _read_one(str(p), tmp_path)
+    assert res is not None
+    assert res["has_pixels"] is True
+
+
+def test_read_one_detects_nonimage(tmp_path: Path) -> None:
+    p = tmp_path / "tensor.dcm"
+    _write_dicom(p, with_pixels=False, series_desc="dwi_TENSOR", series_uid="1.2")
+    res = _read_one(str(p), tmp_path)
+    assert res is not None
+    assert res["has_pixels"] is False
+
+
+# ---------------------------------------------------------------------------
+# scan_dicoms_long aggregation -> internal _has_pixel_data column
+# ---------------------------------------------------------------------------
+
+
+def test_scan_aggregates_pixel_presence(tmp_path: Path) -> None:
+    # One image series (2 files) + one non-image series (1 file), same subject.
+    img_uid, ten_uid = "1.10", "1.20"
+    _write_dicom(tmp_path / "a1.dcm", with_pixels=True, series_desc="t1_mprage", series_uid=img_uid)
+    _write_dicom(tmp_path / "a2.dcm", with_pixels=True, series_desc="t1_mprage", series_uid=img_uid)
+    _write_dicom(tmp_path / "t.dcm", with_pixels=False, series_desc="dwi_TENSOR", series_uid=ten_uid)
+
+    df = scan_dicoms_long(tmp_path, n_jobs=1)
+    assert "_has_pixel_data" in df.columns
+
+    img = df[df["series_uid"] == img_uid].iloc[0]
+    ten = df[df["series_uid"] == ten_uid].iloc[0]
+    assert bool(img["_has_pixel_data"]) is True
+    assert bool(ten["_has_pixel_data"]) is False
+
+
+# ---------------------------------------------------------------------------
+# _is_nonimage_flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (False, True),          # explicit False -> non-image
+        (True, False),          # explicit True -> image
+        (float("nan"), False),  # fmap-collapsed / EEG rows -> image
+        ("", False),
+        ("False", True),        # stringified survives a round-trip
+        ("True", False),
+        (0, True),
+        (1, False),
+    ],
+)
+def test_is_nonimage_flag(val, expected: bool) -> None:
+    assert _is_nonimage_flag(val) is expected
+
+
+# ---------------------------------------------------------------------------
+# _flag_nonimage_rows
+# ---------------------------------------------------------------------------
+
+
+def test_flag_nonimage_rows_excludes_and_annotates() -> None:
+    df = pd.DataFrame([
+        {"_has_pixel_data": True,  "include": 1, "bids_guess_skip": False, "proposed_issues": ""},
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False, "proposed_issues": ""},
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False, "proposed_issues": "trivial: x"},
+    ])
+    _flag_nonimage_rows(df)
+
+    # Image row untouched.
+    assert df.at[0, "include"] == 1
+    assert not bool(df.at[0, "bids_guess_skip"])
+    assert df.at[0, "proposed_issues"] == ""
+
+    # Non-image row excluded + annotated.
+    assert df.at[1, "include"] == 0
+    assert bool(df.at[1, "bids_guess_skip"])
+    assert NONIMAGE_ISSUE_TOKEN in df.at[1, "proposed_issues"]
+
+    # Existing issue preserved after the prepended non-image note.
+    assert NONIMAGE_ISSUE_TOKEN in df.at[2, "proposed_issues"]
+    assert "trivial: x" in df.at[2, "proposed_issues"]
+
+
+def test_flag_nonimage_rows_noop_without_column() -> None:
+    df = pd.DataFrame([{"include": 1, "bids_guess_skip": False, "proposed_issues": ""}])
+    _flag_nonimage_rows(df)  # no _has_pixel_data column -> no-op
+    assert df.at[0, "include"] == 1
+
+
+def test_physio_rows_are_exempt_from_nonimage_flag() -> None:
+    """Siemens physio (_PhysioLog.dcm) has no pixel data either, but it IS
+    convertible by the bidsphysio backend -> must NOT be flagged/excluded."""
+    df = pd.DataFrame([
+        # physio identified by suffix
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False,
+         "proposed_issues": "", "bids_guess_suffix": "physio", "modality": "physio",
+         "proposed_basename": "sub-001_task-rest_physio"},
+        # a genuine non-image object (TENSOR) for contrast
+        {"_has_pixel_data": False, "include": 1, "bids_guess_skip": False,
+         "proposed_issues": "", "bids_guess_suffix": "TENSOR", "modality": "dwi",
+         "proposed_basename": "sub-001_desc-TENSOR_dwi"},
+    ])
+    _flag_nonimage_rows(df)
+
+    # Physio row untouched.
+    assert df.at[0, "include"] == 1
+    assert not bool(df.at[0, "bids_guess_skip"])
+    assert NONIMAGE_ISSUE_TOKEN not in df.at[0, "proposed_issues"]
+
+    # TENSOR row still flagged.
+    assert df.at[1, "include"] == 0
+    assert bool(df.at[1, "bids_guess_skip"])
+    assert NONIMAGE_ISSUE_TOKEN in df.at[1, "proposed_issues"]


### PR DESCRIPTION
Non-image detection
- inventory/mri_dicom: stamp has_pixels (Rows + Columns) per DICOM and OR it per series into the internal _has_pixel_data column (dropped from the final TSV, 51-column contract unchanged).
- cli/scan._flag_nonimage_rows: any series whose files all lack pixel data is forced include=0 + bids_guess_skip with a "non-image series" note in proposed_issues. Catches Siemens TENSOR maps, PhoenixZIPReport, spectroscopy: DERIVED objects dcm2niix cannot convert (was failing rc=2).
- GUI: new "noimg" row state (teal wash) + status badge + hover tooltip surfacing proposed_issues, so non-image rows are visible and flagged rather than silently failing the converter.

Physio fixes (uncovered by real-data testing)
- cli/scan._is_physio_row: physio rows carry no pixel data but ARE convertible by the bidsphysio backend, so they are exempt from the non-image flag.
- vendor/bidsphysio plug_missing_data: rewritten from an O(n^2) one-insertion-at-a-time loop (hung for minutes on a real 22M-sample ECG) to a vectorised single pass. Documented in vendor/README.md.
- converter/backends/physio_dcm: detect outputs by globbing the basename stem so multi-rate physio (<stem>_recording-<label>_physio.*) is no longer mis-reported as producing no output.

Tests: + non-image detection (engine + GUI), + plug_missing_data correctness/perf.